### PR TITLE
[codex] Fix Cloudinary cleanup before record deletes

### DIFF
--- a/app/api/custom-entities/[id]/route.ts
+++ b/app/api/custom-entities/[id]/route.ts
@@ -4,6 +4,10 @@ import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 import redis from '@/lib/redis';
+import {
+  cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets,
+} from '@/lib/cloudinary-cleanup';
 
 const customEntitySchema = z.object({
   collectionType: z.string().min(1, 'Collection type is required'),
@@ -216,11 +220,38 @@ export async function DELETE(
       );
     }
 
-    await transactionsCollection.deleteMany({
+    const transactionDeleteFilter = {
       entityId: id,
       entityType: entity.collectionType,
       userId,
-    });
+    };
+    const transactionsToDelete = await transactionsCollection
+      .find(transactionDeleteFilter, { projection: { billPublicId: 1, billUrl: 1 } })
+      .toArray();
+    const assetRefs = [
+      ...cloudinaryAssetsFromFields({
+        publicIds: [entity.openingBalanceBillPublicId],
+        urls: [entity.openingBalanceBillUrl],
+      }),
+      ...transactionsToDelete.flatMap((transaction) =>
+        cloudinaryAssetsFromFields({
+          publicIds: [transaction.billPublicId],
+          urls: [transaction.billUrl],
+        })
+      ),
+    ];
+
+    try {
+      await deleteCloudinaryAssets(assetRefs);
+    } catch (error) {
+      console.error('Failed to delete custom entity assets:', error);
+      return NextResponse.json(
+        { error: 'Failed to delete associated uploaded files' },
+        { status: 502 }
+      );
+    }
+
+    await transactionsCollection.deleteMany(transactionDeleteFilter);
 
     const result = await customEntitiesCollection.deleteOne({
       _id: new ObjectId(id),
@@ -253,4 +284,3 @@ export async function DELETE(
     );
   }
 }
-

--- a/app/api/customers/[id]/route.ts
+++ b/app/api/customers/[id]/route.ts
@@ -4,6 +4,10 @@ import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 import redis from '@/lib/redis';
+import {
+  cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets,
+} from '@/lib/cloudinary-cleanup';
 
 const customerSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -164,13 +168,51 @@ export async function DELETE(
     const db = await getDb();
     const customersCollection = db.collection('customers');
     const transactionsCollection = db.collection('transactions');
+    const customer = await customersCollection.findOne({
+      _id: new ObjectId(id),
+      userId,
+    });
 
-    await transactionsCollection.deleteMany({
+    if (!customer) {
+      return NextResponse.json(
+        { error: 'Customer not found' },
+        { status: 404 }
+      );
+    }
+
+    const transactionDeleteFilter = {
       $or: [
         { customerId: id, userId },
         { entityId: id, entityType: 'customer', userId }
       ]
-    });
+    };
+    const transactionsToDelete = await transactionsCollection
+      .find(transactionDeleteFilter, { projection: { billPublicId: 1, billUrl: 1 } })
+      .toArray();
+    const assetRefs = [
+      ...cloudinaryAssetsFromFields({
+        publicIds: [customer.openingBalanceBillPublicId],
+        urls: [customer.openingBalanceBillUrl],
+      }),
+      ...transactionsToDelete.flatMap((transaction) =>
+        cloudinaryAssetsFromFields({
+          publicIds: [transaction.billPublicId],
+          urls: [transaction.billUrl],
+        })
+      ),
+    ];
+
+    try {
+      await deleteCloudinaryAssets(assetRefs);
+    } catch (error) {
+      console.error('Failed to delete customer assets:', error);
+      return NextResponse.json(
+        { error: 'Failed to delete associated uploaded files' },
+        { status: 502 }
+      );
+    }
+
+    await transactionsCollection.deleteMany(transactionDeleteFilter);
 
     const result = await customersCollection.deleteOne({
       _id: new ObjectId(id),
@@ -199,4 +241,3 @@ export async function DELETE(
     );
   }
 }
-

--- a/app/api/daily-cash-records/[id]/route.ts
+++ b/app/api/daily-cash-records/[id]/route.ts
@@ -291,14 +291,20 @@ export async function DELETE(
     );
     const dateKey = format(record.date, 'dd-MM-yyyy');
 
-    if (entryToDelete.billPublicId) {
-      try {
-        const { deleteAsset } = await import('@/lib/cloudinary');
-        const resourceType = entryToDelete.billUrl?.toLowerCase().includes('.pdf') ? 'raw' : 'image';
-        await deleteAsset(entryToDelete.billPublicId, resourceType);
-      } catch (error) {
-        console.warn('Failed to delete bill asset during daily cash entry delete:', error);
-      }
+    try {
+      const { cloudinaryAssetsFromFields, deleteCloudinaryAssets } = await import('@/lib/cloudinary-cleanup');
+      await deleteCloudinaryAssets(
+        cloudinaryAssetsFromFields({
+          publicIds: [entryToDelete.billPublicId],
+          urls: [entryToDelete.billUrl],
+        })
+      );
+    } catch (error) {
+      console.error('Failed to delete bill asset during daily cash entry delete:', error);
+      return NextResponse.json(
+        { error: 'Failed to delete associated uploaded files' },
+        { status: 502 }
+      );
     }
 
     if (updatedEntries.length === 0) {

--- a/app/api/inventory/[id]/route.ts
+++ b/app/api/inventory/[id]/route.ts
@@ -11,6 +11,10 @@ import {
 } from '@/lib/cache';
 import { z } from 'zod';
 import { uppercaseInventoryPayload } from '@/lib/inventory-text';
+import {
+  cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets,
+} from '@/lib/cloudinary-cleanup';
 
 const optionalDateSchema = z.preprocess(
   (value) => {
@@ -30,6 +34,7 @@ const inventoryItemSchema = z.object({
   location: z.string().trim().min(1, 'Location is required'),
   unitOfMeasure: z.string().trim().min(1, 'Unit of measure is required'),
   partImages: z.array(z.string().url('Invalid part image URL')).optional(),
+  partImagePublicIds: z.array(z.string().trim().min(1)).optional(),
   brand: z.string().trim().optional(),
   description: z.string().trim().optional(),
   buyingPrice: z.number().min(0, 'Buying price cannot be negative').optional().nullable(),
@@ -37,6 +42,7 @@ const inventoryItemSchema = z.object({
   supplier: z.string().trim().optional(),
   billingDate: optionalDateSchema,
   billImages: z.array(z.string().url('Invalid bill image URL')).optional(),
+  billImagePublicIds: z.array(z.string().trim().min(1)).optional(),
 });
 
 function serializeInventoryItem(item: InventoryItem & { _id: { toString(): string } }) {
@@ -49,6 +55,7 @@ function serializeInventoryItem(item: InventoryItem & { _id: { toString(): strin
     location: item.location || '',
     unitOfMeasure: item.unitOfMeasure || '',
     partImages: item.partImages || [],
+    partImagePublicIds: item.partImagePublicIds || [],
     brand: item.brand || '',
     description: item.description || '',
     buyingPrice: item.buyingPrice ?? undefined,
@@ -56,6 +63,7 @@ function serializeInventoryItem(item: InventoryItem & { _id: { toString(): strin
     supplier: item.supplier || '',
     billingDate: item.billingDate,
     billImages: item.billImages || [],
+    billImagePublicIds: item.billImagePublicIds || [],
     lastQuantityUpdatedAt: item.lastQuantityUpdatedAt,
     createdAt: item.createdAt,
     updatedAt: item.updatedAt,
@@ -71,6 +79,7 @@ function normalizeItemInput(data: z.infer<typeof inventoryItemSchema>) {
     location: data.location,
     unitOfMeasure: data.unitOfMeasure,
     partImages: data.partImages || [],
+    partImagePublicIds: data.partImagePublicIds || [],
     brand: data.brand || '',
     description: data.description || '',
     buyingPrice: data.buyingPrice ?? undefined,
@@ -78,6 +87,7 @@ function normalizeItemInput(data: z.infer<typeof inventoryItemSchema>) {
     supplier: data.supplier || '',
     billingDate: data.billingDate,
     billImages: data.billImages || [],
+    billImagePublicIds: data.billImagePublicIds || [],
   });
 }
 
@@ -255,6 +265,7 @@ const quantityPatchSchema = z
 const imagePatchSchema = z.object({
   imageField: z.enum(['partImages', 'billImages']),
   url: z.string().url('Invalid image URL'),
+  publicId: z.string().trim().min(1).optional(),
 }).strict();
 
 const inventoryPatchSchema = z.union([quantityPatchSchema, imagePatchSchema]);
@@ -283,10 +294,17 @@ export async function PATCH(
     const updatedAt = new Date();
 
     if ('imageField' in patch) {
+      const publicIdField =
+        patch.imageField === 'partImages' ? 'partImagePublicIds' : 'billImagePublicIds';
+      const addToSet: Record<string, string> = { [patch.imageField]: patch.url };
+      if (patch.publicId) {
+        addToSet[publicIdField] = patch.publicId;
+      }
+
       const result = await inventoryCollection.findOneAndUpdate(
         { _id: objectId, userId },
         {
-          $addToSet: { [patch.imageField]: patch.url },
+          $addToSet: addToSet,
           $set: { updatedAt },
         },
         { returnDocument: 'after' }
@@ -401,6 +419,35 @@ export async function DELETE(
 
     const db = await getDb();
     const inventoryCollection = db.collection('inventory');
+    const item = await inventoryCollection.findOne({ _id: objectId, userId });
+
+    if (!item) {
+      return NextResponse.json({ error: 'Inventory item not found' }, { status: 404 });
+    }
+
+    const assetRefs = [
+      ...cloudinaryAssetsFromFields({
+        publicIds: item.partImagePublicIds || [],
+        urls: item.partImages || [],
+        defaultResourceType: 'image',
+      }),
+      ...cloudinaryAssetsFromFields({
+        publicIds: item.billImagePublicIds || [],
+        urls: item.billImages || [],
+        defaultResourceType: 'image',
+      }),
+    ];
+
+    try {
+      await deleteCloudinaryAssets(assetRefs);
+    } catch (error) {
+      console.error('Failed to delete inventory item assets:', error);
+      return NextResponse.json(
+        { error: 'Failed to delete associated uploaded files' },
+        { status: 502 }
+      );
+    }
+
     const result = await inventoryCollection.deleteOne({ _id: objectId, userId });
 
     if (result.deletedCount === 0) {

--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -55,6 +55,7 @@ const inventoryItemSchema = z.object({
   location: z.string().trim().min(1, 'Location is required'),
   unitOfMeasure: z.string().trim().min(1, 'Unit of measure is required'),
   partImages: z.array(z.string().url('Invalid part image URL')).optional(),
+  partImagePublicIds: z.array(z.string().trim().min(1)).optional(),
   brand: z.string().trim().optional(),
   description: z.string().trim().optional(),
   buyingPrice: z.number().min(0, 'Buying price cannot be negative').optional().nullable(),
@@ -62,6 +63,7 @@ const inventoryItemSchema = z.object({
   supplier: z.string().trim().optional(),
   billingDate: optionalDateSchema,
   billImages: z.array(z.string().url('Invalid bill image URL')).optional(),
+  billImagePublicIds: z.array(z.string().trim().min(1)).optional(),
 });
 
 function escapeRegex(value: string) {
@@ -78,6 +80,7 @@ function serializeInventoryItem(item: InventoryItem & { _id: { toString(): strin
     location: item.location || '',
     unitOfMeasure: item.unitOfMeasure || '',
     partImages: item.partImages || [],
+    partImagePublicIds: item.partImagePublicIds || [],
     brand: item.brand || '',
     description: item.description || '',
     buyingPrice: item.buyingPrice ?? undefined,
@@ -85,6 +88,7 @@ function serializeInventoryItem(item: InventoryItem & { _id: { toString(): strin
     supplier: item.supplier || '',
     billingDate: item.billingDate,
     billImages: item.billImages || [],
+    billImagePublicIds: item.billImagePublicIds || [],
     lastQuantityUpdatedAt: item.lastQuantityUpdatedAt,
     createdAt: item.createdAt,
     updatedAt: item.updatedAt,
@@ -100,6 +104,7 @@ function normalizeItemInput(data: z.infer<typeof inventoryItemSchema>) {
     location: data.location,
     unitOfMeasure: data.unitOfMeasure,
     partImages: data.partImages || [],
+    partImagePublicIds: data.partImagePublicIds || [],
     brand: data.brand || '',
     description: data.description || '',
     buyingPrice: data.buyingPrice ?? undefined,
@@ -107,6 +112,7 @@ function normalizeItemInput(data: z.infer<typeof inventoryItemSchema>) {
     supplier: data.supplier || '',
     billingDate: data.billingDate,
     billImages: data.billImages || [],
+    billImagePublicIds: data.billImagePublicIds || [],
   });
 }
 

--- a/app/api/suppliers/[id]/route.ts
+++ b/app/api/suppliers/[id]/route.ts
@@ -4,6 +4,10 @@ import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 import redis from '@/lib/redis';
+import {
+  cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets,
+} from '@/lib/cloudinary-cleanup';
 
 const supplierSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -164,13 +168,51 @@ export async function DELETE(
     const db = await getDb();
     const suppliersCollection = db.collection('suppliers');
     const transactionsCollection = db.collection('transactions');
+    const supplier = await suppliersCollection.findOne({
+      _id: new ObjectId(id),
+      userId,
+    });
 
-    await transactionsCollection.deleteMany({
+    if (!supplier) {
+      return NextResponse.json(
+        { error: 'Supplier not found' },
+        { status: 404 }
+      );
+    }
+
+    const transactionDeleteFilter = {
       $or: [
         { supplierId: id, userId },
         { entityId: id, entityType: 'supplier', userId }
       ]
-    });
+    };
+    const transactionsToDelete = await transactionsCollection
+      .find(transactionDeleteFilter, { projection: { billPublicId: 1, billUrl: 1 } })
+      .toArray();
+    const assetRefs = [
+      ...cloudinaryAssetsFromFields({
+        publicIds: [supplier.openingBalanceBillPublicId],
+        urls: [supplier.openingBalanceBillUrl],
+      }),
+      ...transactionsToDelete.flatMap((transaction) =>
+        cloudinaryAssetsFromFields({
+          publicIds: [transaction.billPublicId],
+          urls: [transaction.billUrl],
+        })
+      ),
+    ];
+
+    try {
+      await deleteCloudinaryAssets(assetRefs);
+    } catch (error) {
+      console.error('Failed to delete supplier assets:', error);
+      return NextResponse.json(
+        { error: 'Failed to delete associated uploaded files' },
+        { status: 502 }
+      );
+    }
+
+    await transactionsCollection.deleteMany(transactionDeleteFilter);
 
     const result = await suppliersCollection.deleteOne({
       _id: new ObjectId(id),
@@ -199,4 +241,3 @@ export async function DELETE(
     );
   }
 }
-

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -4,7 +4,10 @@ import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 import redis from '@/lib/redis';
-import { deleteAsset } from '@/lib/cloudinary';
+import {
+  cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets,
+} from '@/lib/cloudinary-cleanup';
 
 const transactionSchema = z
   .object({
@@ -169,9 +172,18 @@ export async function PUT(
 
     if ((removingBill || replacingBill) && existingPublicId) {
       try {
-        await deleteAsset(existingPublicId);
+        await deleteCloudinaryAssets(
+          cloudinaryAssetsFromFields({
+            publicIds: [existingPublicId],
+            urls: [existingTransaction.billUrl],
+          })
+        );
       } catch (error) {
-        console.warn('Failed to delete existing bill asset:', error);
+        console.error('Failed to delete existing bill asset:', error);
+        return NextResponse.json(
+          { error: 'Failed to delete associated uploaded files' },
+          { status: 502 }
+        );
       }
     }
 
@@ -302,12 +314,19 @@ export async function DELETE(
       );
     }
 
-    if (transaction.billPublicId) {
-      try {
-        await deleteAsset(transaction.billPublicId);
-      } catch (error) {
-        console.warn('Failed to delete bill asset during transaction delete:', error);
-      }
+    try {
+      await deleteCloudinaryAssets(
+        cloudinaryAssetsFromFields({
+          publicIds: [transaction.billPublicId],
+          urls: [transaction.billUrl],
+        })
+      );
+    } catch (error) {
+      console.error('Failed to delete bill asset during transaction delete:', error);
+      return NextResponse.json(
+        { error: 'Failed to delete associated uploaded files' },
+        { status: 502 }
+      );
     }
 
     const result = await transactionsCollection.deleteOne({
@@ -352,4 +371,3 @@ export async function DELETE(
     );
   }
 }
-

--- a/app/inventory-items/page.tsx
+++ b/app/inventory-items/page.tsx
@@ -122,6 +122,7 @@ const inventoryItemSchema = z.object({
   location: z.string().min(1, 'Location is required'),
   unitOfMeasure: z.string().min(1, 'Unit is required'),
   partImages: z.array(z.string()).default([]),
+  partImagePublicIds: z.array(z.string()).default([]),
   brand: z.string().optional(),
   description: z.string().optional(),
   buyingPrice: z.number().min(0, 'Buying price cannot be negative').optional(),
@@ -133,6 +134,7 @@ const inventoryItemSchema = z.object({
     .refine((s) => !s?.trim() || /^\d{2}\/\d{2}\/\d{4}$/.test(s.trim()), 'Use DD/MM/YYYY')
     .refine((s) => !s?.trim() || parseDdMmYyyyToIsoDate(s.trim()) !== undefined, 'Invalid billing date'),
   billImages: z.array(z.string()).default([]),
+  billImagePublicIds: z.array(z.string()).default([]),
 });
 
 type InventoryItemForm = z.input<typeof inventoryItemSchema>;
@@ -149,6 +151,7 @@ interface InventoryItem {
   location: string;
   unitOfMeasure: string;
   partImages: string[];
+  partImagePublicIds: string[];
   brand?: string;
   description?: string;
   buyingPrice?: number;
@@ -156,6 +159,7 @@ interface InventoryItem {
   supplier?: string;
   billingDate?: string;
   billImages: string[];
+  billImagePublicIds: string[];
   lastQuantityUpdatedAt?: string;
   createdAt: string;
   updatedAt: string;
@@ -192,6 +196,7 @@ const defaultFormValues: InventoryItemForm = {
   location: '',
   unitOfMeasure: 'pcs',
   partImages: [],
+  partImagePublicIds: [],
   brand: '',
   description: '',
   buyingPrice: undefined,
@@ -199,6 +204,7 @@ const defaultFormValues: InventoryItemForm = {
   supplier: '',
   billingDate: '',
   billImages: [],
+  billImagePublicIds: [],
 };
 
 const statusTabs: Array<{ value: StatusFilter; label: string }> = [
@@ -323,8 +329,28 @@ function normalizeSubmission(values: InventoryItemForm) {
     supplier: values.supplier?.trim() || '',
     billingDate: parseDdMmYyyyToIsoDate(values.billingDate?.trim() || '') || undefined,
     partImages: values.partImages || [],
+    partImagePublicIds: values.partImagePublicIds || [],
     billImages: values.billImages || [],
+    billImagePublicIds: values.billImagePublicIds || [],
   };
+}
+
+function getImagePublicIdField(fieldName: 'partImages' | 'billImages') {
+  return fieldName === 'partImages' ? 'partImagePublicIds' : 'billImagePublicIds';
+}
+
+function mapImagePublicIds(
+  urls?: string[],
+  publicIds?: string[],
+  existing = new Map<string, string>()
+) {
+  (urls || []).forEach((url, index) => {
+    const publicId = publicIds?.[index];
+    if (url && publicId) {
+      existing.set(url, publicId);
+    }
+  });
+  return existing;
 }
 
 function ItemImageCarousel({ images, itemName }: { images: string[]; itemName: string }) {
@@ -1238,7 +1264,17 @@ export default function InventoryItemsPage() {
         });
 
         (['partImages', 'billImages'] as const).forEach((fieldName) => {
+          const publicIdField = getImagePublicIdField(fieldName);
           const serverUrls = new Set((result.item?.[fieldName] || []) as string[]);
+          const publicIdByUrl = mapImagePublicIds(
+            (values[fieldName] || []) as string[],
+            (values[publicIdField] || []) as string[]
+          );
+          mapImagePublicIds(
+            (form.getValues(fieldName) || []) as string[],
+            (form.getValues(publicIdField) || []) as string[],
+            publicIdByUrl
+          );
           const latestUrls = Array.from(
             new Set([
               ...(((values[fieldName] || []) as string[])),
@@ -1247,7 +1283,7 @@ export default function InventoryItemsPage() {
           );
           latestUrls
             .filter((url) => !serverUrls.has(url))
-            .forEach((url) => attachImageToSavedItem(savedItemId, fieldName, url));
+            .forEach((url) => attachImageToSavedItem(savedItemId, fieldName, url, publicIdByUrl.get(url)));
         });
       }
       pendingUploadIdsAtSubmitRef.current = new Set();
@@ -1472,6 +1508,7 @@ export default function InventoryItemsPage() {
       location: item.location,
       unitOfMeasure: normalizeUnitForForm(item.unitOfMeasure || ''),
       partImages: item.partImages || [],
+      partImagePublicIds: item.partImagePublicIds || [],
       brand: item.brand || '',
       description: item.description || '',
       buyingPrice: item.buyingPrice,
@@ -1479,19 +1516,20 @@ export default function InventoryItemsPage() {
       supplier: item.supplier || '',
       billingDate: isoOrStoredDateToDdMmYyyy(item.billingDate),
       billImages: item.billImages || [],
+      billImagePublicIds: item.billImagePublicIds || [],
     });
     setFormOpen(true);
   };
 
   const attachImageToSavedItem = useCallback(
-    (itemId: string, fieldName: 'partImages' | 'billImages', url: string) => {
+    (itemId: string, fieldName: 'partImages' | 'billImages', url: string, publicId?: string) => {
       const run = backgroundAttachQueueRef.current
         .catch(() => undefined)
         .then(async () => {
           const response = await fetch(`/api/inventory/${itemId}`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ imageField: fieldName, url }),
+            body: JSON.stringify({ imageField: fieldName, url, publicId }),
           });
           const result = await response.json();
           if (!response.ok) throw new Error(result.error || 'Failed to attach uploaded image');
@@ -1556,13 +1594,16 @@ export default function InventoryItemsPage() {
         if (!response.ok) throw new Error(result.error || 'Upload failed');
 
         const fieldName = kind === 'part' ? 'partImages' : 'billImages';
+        const publicIdField = getImagePublicIdField(fieldName);
         const savedItemId = uploadTargetByTempIdRef.current.get(tempId);
         if (!canceledUploadIdsRef.current.has(tempId)) {
           if (savedItemId) {
-            attachImageToSavedItem(savedItemId, fieldName, result.url);
+            attachImageToSavedItem(savedItemId, fieldName, result.url, result.publicId);
           } else {
             const currentUrls = (form.getValues(fieldName) || []) as string[];
+            const currentPublicIds = (form.getValues(publicIdField) || []) as string[];
             form.setValue(fieldName, [...currentUrls, result.url], { shouldDirty: true });
+            form.setValue(publicIdField, [...currentPublicIds, result.publicId], { shouldDirty: true });
           }
         }
 
@@ -1655,8 +1696,15 @@ export default function InventoryItemsPage() {
   };
 
   const removeImage = (fieldName: 'partImages' | 'billImages', url: string) => {
-    const nextUrls = ((form.getValues(fieldName) || []) as string[]).filter((item) => item !== url);
+    const currentUrls = (form.getValues(fieldName) || []) as string[];
+    const removeIndex = currentUrls.findIndex((item) => item === url);
+    const nextUrls = currentUrls.filter((_, index) => index !== removeIndex);
+    const publicIdField = getImagePublicIdField(fieldName);
+    const nextPublicIds = ((form.getValues(publicIdField) || []) as string[]).filter(
+      (_, index) => index !== removeIndex
+    );
     form.setValue(fieldName, nextUrls, { shouldDirty: true });
+    form.setValue(publicIdField, nextPublicIds, { shouldDirty: true });
   };
 
   const hasItemNumberConflict = itemNumberCheck.status === 'duplicate';

--- a/lib/cloudinary-cleanup.ts
+++ b/lib/cloudinary-cleanup.ts
@@ -1,0 +1,122 @@
+export type CloudinaryResourceType = 'image' | 'raw' | 'video';
+
+export type CloudinaryAssetRef = {
+  publicId: string;
+  resourceType?: CloudinaryResourceType;
+};
+
+function normalizePublicId(publicId?: string | null) {
+  const trimmed = publicId?.trim();
+  return trimmed || undefined;
+}
+
+function resourceTypeFromPublicId(publicId: string): CloudinaryResourceType | undefined {
+  return /\.pdf$/i.test(publicId) ? 'raw' : undefined;
+}
+
+function resourceTypeFromUrl(url?: string | null): CloudinaryResourceType | undefined {
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    const resourceType = parts[1];
+    if (resourceType === 'image' || resourceType === 'raw' || resourceType === 'video') {
+      return resourceType;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function cloudinaryAssetFromUrl(url?: string | null): CloudinaryAssetRef | null {
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    const resourceType = parts[1];
+    const uploadIndex = parts.indexOf('upload');
+
+    if (
+      uploadIndex === -1 ||
+      (resourceType !== 'image' && resourceType !== 'raw' && resourceType !== 'video')
+    ) {
+      return null;
+    }
+
+    const publicIdParts = parts.slice(uploadIndex + 1);
+    if (publicIdParts[0]?.match(/^v\d+$/)) {
+      publicIdParts.shift();
+    }
+
+    let publicId = decodeURIComponent(publicIdParts.join('/'));
+    if (!publicId) return null;
+
+    if (resourceType === 'image' || resourceType === 'video') {
+      publicId = publicId.replace(/\.[^.\/]+$/, '');
+    }
+
+    return { publicId, resourceType };
+  } catch {
+    return null;
+  }
+}
+
+export function cloudinaryAssetsFromFields({
+  publicIds = [],
+  urls = [],
+  defaultResourceType = 'image',
+}: {
+  publicIds?: Array<string | null | undefined>;
+  urls?: Array<string | null | undefined>;
+  defaultResourceType?: CloudinaryResourceType;
+}): CloudinaryAssetRef[] {
+  const refs: CloudinaryAssetRef[] = [];
+
+  publicIds.forEach((publicId, index) => {
+    const normalized = normalizePublicId(publicId);
+    if (!normalized) return;
+
+    refs.push({
+      publicId: normalized,
+      resourceType:
+        resourceTypeFromUrl(urls[index]) ??
+        resourceTypeFromPublicId(normalized) ??
+        defaultResourceType,
+    });
+  });
+
+  urls.forEach((url, index) => {
+    if (normalizePublicId(publicIds[index])) return;
+
+    const parsed = cloudinaryAssetFromUrl(url);
+    if (parsed) refs.push(parsed);
+  });
+
+  return refs;
+}
+
+export async function deleteCloudinaryAssets(assetRefs: CloudinaryAssetRef[]) {
+  const uniqueRefs = new Map<string, Required<CloudinaryAssetRef>>();
+
+  assetRefs.forEach((assetRef) => {
+    const publicId = normalizePublicId(assetRef.publicId);
+    if (!publicId) return;
+
+    const resourceType = assetRef.resourceType ?? resourceTypeFromPublicId(publicId) ?? 'image';
+    uniqueRefs.set(`${resourceType}:${publicId}`, { publicId, resourceType });
+  });
+
+  if (uniqueRefs.size === 0) return;
+
+  const { deleteAsset } = await import('@/lib/cloudinary');
+
+  await Promise.all(
+    Array.from(uniqueRefs.values()).map((assetRef) =>
+      deleteAsset(assetRef.publicId, assetRef.resourceType)
+    )
+  );
+}

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -1,5 +1,7 @@
 import { v2 as cloudinary, UploadApiOptions, UploadApiResponse } from 'cloudinary';
 
+export type CloudinaryResourceType = 'image' | 'raw' | 'video';
+
 const cloudName = process.env.CLOUDINARY_CLOUD_NAME ?? process.env.CLOUD_NAME;
 const apiKey = process.env.CLOUDINARY_API_KEY ?? process.env.API_KEY;
 const apiSecret = process.env.CLOUDINARY_API_SECRET ?? process.env.API_SECRET;
@@ -35,7 +37,6 @@ export async function uploadBuffer(
   });
 }
 
-export async function deleteAsset(publicId: string, resourceType: 'image' | 'raw' | 'video' = 'image') {
+export async function deleteAsset(publicId: string, resourceType: CloudinaryResourceType = 'image') {
   await cloudinary.uploader.destroy(publicId, { resource_type: resourceType });
 }
-

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -154,6 +154,7 @@ export interface InventoryItem {
   location: string;
   unitOfMeasure: string;
   partImages?: string[];
+  partImagePublicIds?: string[];
   brand?: string;
   description?: string;
   buyingPrice?: number;
@@ -161,6 +162,7 @@ export interface InventoryItem {
   supplier?: string;
   billingDate?: Date;
   billImages?: string[];
+  billImagePublicIds?: string[];
   lastQuantityUpdatedAt?: Date;
   createdAt: Date;
   updatedAt: Date;

--- a/tests/api/customer-id.test.ts
+++ b/tests/api/customer-id.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ids, jsonRequest, objectIdLike, routeParams } from '@/tests/helpers/api';
+
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  getUserIdFromRequest: vi.fn(),
+  redisDel: vi.fn(),
+  cloudinaryAssetsFromFields: vi.fn(),
+  deleteCloudinaryAssets: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getUserIdFromRequest: mocks.getUserIdFromRequest,
+}));
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: mocks.getDb,
+}));
+
+vi.mock('@/lib/redis', () => ({
+  default: {
+    del: mocks.redisDel,
+  },
+}));
+
+vi.mock('@/lib/cloudinary-cleanup', () => ({
+  cloudinaryAssetsFromFields: mocks.cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets: mocks.deleteCloudinaryAssets,
+}));
+
+describe('/api/customers/[id]', () => {
+  beforeEach(() => {
+    mocks.getDb.mockReset();
+    mocks.getUserIdFromRequest.mockReset();
+    mocks.redisDel.mockReset();
+    mocks.cloudinaryAssetsFromFields.mockReset();
+    mocks.deleteCloudinaryAssets.mockReset();
+
+    mocks.getUserIdFromRequest.mockReturnValue(ids.user);
+    mocks.redisDel.mockResolvedValue(1);
+    mocks.cloudinaryAssetsFromFields.mockImplementation(({ publicIds }) =>
+      (publicIds || []).filter(Boolean).map((publicId: string) => ({ publicId }))
+    );
+    mocks.deleteCloudinaryAssets.mockResolvedValue(undefined);
+  });
+
+  it('deletes opening balance and transaction bill assets before deleting customer records', async () => {
+    const customer = {
+      _id: objectIdLike(ids.customer),
+      openingBalanceBillUrl: 'https://res.cloudinary.com/demo/image/upload/opening.jpg',
+      openingBalanceBillPublicId: 'customers/opening',
+    };
+    const transactionCursor = {
+      toArray: vi.fn().mockResolvedValue([
+        {
+          billUrl: 'https://res.cloudinary.com/demo/image/upload/transaction.jpg',
+          billPublicId: 'transactions/bill',
+        },
+      ]),
+    };
+    const customers = {
+      findOne: vi.fn().mockResolvedValue(customer),
+      deleteOne: vi.fn().mockResolvedValue({ deletedCount: 1 }),
+    };
+    const transactions = {
+      find: vi.fn(() => transactionCursor),
+      deleteMany: vi.fn().mockResolvedValue({ deletedCount: 1 }),
+    };
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn((name: string) => (name === 'customers' ? customers : transactions)),
+    });
+
+    const { DELETE } = await import('@/app/api/customers/[id]/route');
+    const response = await DELETE(
+      jsonRequest('http://localhost/api/customers/customer', undefined, { method: 'DELETE' }),
+      routeParams({ id: ids.customer })
+    );
+
+    expect(response.status).toBe(200);
+    expect(transactions.find).toHaveBeenCalledWith(
+      {
+        $or: [
+          { customerId: ids.customer, userId: ids.user },
+          { entityId: ids.customer, entityType: 'customer', userId: ids.user },
+        ],
+      },
+      { projection: { billPublicId: 1, billUrl: 1 } }
+    );
+    expect(mocks.deleteCloudinaryAssets).toHaveBeenCalledWith([
+      { publicId: 'customers/opening' },
+      { publicId: 'transactions/bill' },
+    ]);
+    expect(mocks.deleteCloudinaryAssets.mock.invocationCallOrder[0]).toBeLessThan(
+      transactions.deleteMany.mock.invocationCallOrder[0]
+    );
+    expect(transactions.deleteMany).toHaveBeenCalled();
+    expect(customers.deleteOne).toHaveBeenCalledWith({ _id: expect.any(Object), userId: ids.user });
+  });
+
+  it('keeps customer and transaction records when Cloudinary cleanup fails', async () => {
+    const customers = {
+      findOne: vi.fn().mockResolvedValue({
+        _id: objectIdLike(ids.customer),
+        openingBalanceBillPublicId: 'customers/opening',
+      }),
+      deleteOne: vi.fn(),
+    };
+    const transactions = {
+      find: vi.fn(() => ({ toArray: vi.fn().mockResolvedValue([]) })),
+      deleteMany: vi.fn(),
+    };
+    mocks.deleteCloudinaryAssets.mockRejectedValue(new Error('Cloudinary unavailable'));
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn((name: string) => (name === 'customers' ? customers : transactions)),
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { DELETE } = await import('@/app/api/customers/[id]/route');
+    const response = await DELETE(
+      jsonRequest('http://localhost/api/customers/customer', undefined, { method: 'DELETE' }),
+      routeParams({ id: ids.customer })
+    );
+    error.mockRestore();
+
+    expect(response.status).toBe(502);
+    expect(transactions.deleteMany).not.toHaveBeenCalled();
+    expect(customers.deleteOne).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to delete associated uploaded files',
+    });
+  });
+});

--- a/tests/api/inventory-id.test.ts
+++ b/tests/api/inventory-id.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   redisDel: vi.fn(),
   inventoryItemKey: vi.fn(),
   invalidateInventoryCache: vi.fn(),
+  cloudinaryAssetsFromFields: vi.fn(),
+  deleteCloudinaryAssets: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -33,6 +35,11 @@ vi.mock('@/lib/cache', () => ({
   invalidateInventoryCache: mocks.invalidateInventoryCache,
 }));
 
+vi.mock('@/lib/cloudinary-cleanup', () => ({
+  cloudinaryAssetsFromFields: mocks.cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets: mocks.deleteCloudinaryAssets,
+}));
+
 const storedItem = {
   _id: objectIdLike(ids.inventory),
   itemName: 'BRAKE PAD',
@@ -42,12 +49,14 @@ const storedItem = {
   location: 'FRONT SHELF',
   unitOfMeasure: 'PCS',
   partImages: [],
+  partImagePublicIds: [],
   brand: 'BOSCH',
   description: 'FRONT WHEEL SET',
   buyingPrice: 450,
   mrp: 650,
   supplier: 'METRO SUPPLIES',
   billImages: [],
+  billImagePublicIds: [],
   lastQuantityUpdatedAt: new Date('2026-06-20T00:00:00.000Z'),
   createdAt: new Date('2026-06-18T00:00:00.000Z'),
   updatedAt: new Date('2026-06-20T00:00:00.000Z'),
@@ -62,6 +71,8 @@ describe('/api/inventory/[id]', () => {
     mocks.redisDel.mockReset();
     mocks.inventoryItemKey.mockReset();
     mocks.invalidateInventoryCache.mockReset();
+    mocks.cloudinaryAssetsFromFields.mockReset();
+    mocks.deleteCloudinaryAssets.mockReset();
 
     mocks.getUserIdFromRequest.mockReturnValue(ids.user);
     mocks.cacheGet.mockResolvedValue(null);
@@ -69,6 +80,10 @@ describe('/api/inventory/[id]', () => {
     mocks.redisDel.mockResolvedValue(1);
     mocks.inventoryItemKey.mockReturnValue('inventory:item:key');
     mocks.invalidateInventoryCache.mockResolvedValue(undefined);
+    mocks.cloudinaryAssetsFromFields.mockImplementation(({ publicIds }) =>
+      (publicIds || []).filter(Boolean).map((publicId: string) => ({ publicId }))
+    );
+    mocks.deleteCloudinaryAssets.mockResolvedValue(undefined);
   });
 
   it('rejects invalid ids before cache or database work', async () => {
@@ -166,5 +181,75 @@ describe('/api/inventory/[id]', () => {
         quantity: 0,
       },
     });
+  });
+
+  it('deletes Cloudinary assets before deleting inventory items', async () => {
+    const itemWithImages = {
+      ...storedItem,
+      partImages: ['https://res.cloudinary.com/demo/image/upload/part.jpg'],
+      partImagePublicIds: ['inventory/part'],
+      billImages: ['https://res.cloudinary.com/demo/raw/upload/bill.pdf'],
+      billImagePublicIds: ['inventory/bill.pdf'],
+    };
+    const findOne = vi.fn().mockResolvedValue(itemWithImages);
+    const deleteOne = vi.fn().mockResolvedValue({ deletedCount: 1 });
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne, deleteOne })),
+    });
+
+    const { DELETE } = await import('@/app/api/inventory/[id]/route');
+    const response = await DELETE(
+      jsonRequest('http://localhost/api/inventory/item', undefined, { method: 'DELETE' }),
+      routeParams({ id: ids.inventory })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.cloudinaryAssetsFromFields).toHaveBeenCalledWith({
+      publicIds: ['inventory/part'],
+      urls: ['https://res.cloudinary.com/demo/image/upload/part.jpg'],
+      defaultResourceType: 'image',
+    });
+    expect(mocks.cloudinaryAssetsFromFields).toHaveBeenCalledWith({
+      publicIds: ['inventory/bill.pdf'],
+      urls: ['https://res.cloudinary.com/demo/raw/upload/bill.pdf'],
+      defaultResourceType: 'image',
+    });
+    expect(mocks.deleteCloudinaryAssets).toHaveBeenCalledWith([
+      { publicId: 'inventory/part' },
+      { publicId: 'inventory/bill.pdf' },
+    ]);
+    expect(mocks.deleteCloudinaryAssets.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteOne.mock.invocationCallOrder[0]
+    );
+    expect(deleteOne).toHaveBeenCalledWith({ _id: expect.any(Object), userId: ids.user });
+    expect(mocks.invalidateInventoryCache).toHaveBeenCalledWith(ids.user, ids.inventory);
+  });
+
+  it('does not delete inventory items when Cloudinary cleanup fails', async () => {
+    const findOne = vi.fn().mockResolvedValue({
+      ...storedItem,
+      partImages: ['https://res.cloudinary.com/demo/image/upload/part.jpg'],
+      partImagePublicIds: ['inventory/part'],
+    });
+    const deleteOne = vi.fn();
+    mocks.deleteCloudinaryAssets.mockRejectedValue(new Error('Cloudinary unavailable'));
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne, deleteOne })),
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { DELETE } = await import('@/app/api/inventory/[id]/route');
+    const response = await DELETE(
+      jsonRequest('http://localhost/api/inventory/item', undefined, { method: 'DELETE' }),
+      routeParams({ id: ids.inventory })
+    );
+    error.mockRestore();
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to delete associated uploaded files',
+    });
+    expect(deleteOne).not.toHaveBeenCalled();
+    expect(mocks.invalidateInventoryCache).not.toHaveBeenCalled();
   });
 });

--- a/tests/api/inventory.test.ts
+++ b/tests/api/inventory.test.ts
@@ -51,6 +51,7 @@ const validInventoryBody = {
   location: 'front shelf',
   unitOfMeasure: 'pcs',
   partImages: ['https://res.cloudinary.com/demo/image/upload/part.jpg'],
+  partImagePublicIds: ['inventory/part'],
   brand: 'bosch',
   description: 'front wheel set',
   buyingPrice: 450,
@@ -58,6 +59,7 @@ const validInventoryBody = {
   supplier: 'metro supplies',
   billingDate: '2026-06-20',
   billImages: ['https://res.cloudinary.com/demo/image/upload/bill.jpg'],
+  billImagePublicIds: ['inventory/bill'],
 };
 
 describe('/api/inventory', () => {
@@ -180,6 +182,8 @@ describe('/api/inventory', () => {
         brand: 'BOSCH',
         description: 'FRONT WHEEL SET',
         supplier: 'METRO SUPPLIES',
+        partImagePublicIds: ['inventory/part'],
+        billImagePublicIds: ['inventory/bill'],
         quantity: 8,
         lastQuantityUpdatedAt: expect.any(Date),
         createdAt: expect.any(Date),

--- a/tests/api/transaction-id.test.ts
+++ b/tests/api/transaction-id.test.ts
@@ -5,7 +5,8 @@ const mocks = vi.hoisted(() => ({
   getDb: vi.fn(),
   getUserIdFromRequest: vi.fn(),
   redisDel: vi.fn(),
-  deleteAsset: vi.fn(),
+  cloudinaryAssetsFromFields: vi.fn(),
+  deleteCloudinaryAssets: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -22,8 +23,9 @@ vi.mock('@/lib/redis', () => ({
   },
 }));
 
-vi.mock('@/lib/cloudinary', () => ({
-  deleteAsset: mocks.deleteAsset,
+vi.mock('@/lib/cloudinary-cleanup', () => ({
+  cloudinaryAssetsFromFields: mocks.cloudinaryAssetsFromFields,
+  deleteCloudinaryAssets: mocks.deleteCloudinaryAssets,
 }));
 
 describe('/api/transactions/[id]', () => {
@@ -31,10 +33,14 @@ describe('/api/transactions/[id]', () => {
     mocks.getDb.mockReset();
     mocks.getUserIdFromRequest.mockReset();
     mocks.redisDel.mockReset();
-    mocks.deleteAsset.mockReset();
+    mocks.cloudinaryAssetsFromFields.mockReset();
+    mocks.deleteCloudinaryAssets.mockReset();
     mocks.getUserIdFromRequest.mockReturnValue(ids.user);
     mocks.redisDel.mockResolvedValue(1);
-    mocks.deleteAsset.mockResolvedValue(undefined);
+    mocks.cloudinaryAssetsFromFields.mockImplementation(({ publicIds }) =>
+      (publicIds || []).filter(Boolean).map((publicId: string) => ({ publicId }))
+    );
+    mocks.deleteCloudinaryAssets.mockResolvedValue(undefined);
   });
 
   it('removes replaced bill assets and invalidates old and new entity ledgers when moving transactions', async () => {
@@ -75,7 +81,11 @@ describe('/api/transactions/[id]', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.deleteAsset).toHaveBeenCalledWith('bills/old');
+    expect(mocks.cloudinaryAssetsFromFields).toHaveBeenCalledWith({
+      publicIds: ['bills/old'],
+      urls: ['https://res.cloudinary.com/demo/image/upload/old.jpg'],
+    });
+    expect(mocks.deleteCloudinaryAssets).toHaveBeenCalledWith([{ publicId: 'bills/old' }]);
     expect(updateOne).toHaveBeenCalledWith(
       { _id: expect.any(Object), userId: ids.user },
       expect.objectContaining({
@@ -121,7 +131,11 @@ describe('/api/transactions/[id]', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.deleteAsset).toHaveBeenCalledWith('bills/to-delete');
+    expect(mocks.cloudinaryAssetsFromFields).toHaveBeenCalledWith({
+      publicIds: ['bills/to-delete'],
+      urls: [undefined],
+    });
+    expect(mocks.deleteCloudinaryAssets).toHaveBeenCalledWith([{ publicId: 'bills/to-delete' }]);
     expect(deleteOne).toHaveBeenCalledWith({ _id: expect.any(Object), userId: ids.user });
     expect(mocks.redisDel).toHaveBeenCalledWith(
       `dashboard:stats:${ids.user}`,

--- a/tests/unit/cloudinary-cleanup.test.ts
+++ b/tests/unit/cloudinary-cleanup.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cloudinaryAssetFromUrl,
+  cloudinaryAssetsFromFields,
+} from '@/lib/cloudinary-cleanup';
+
+describe('cloudinary cleanup helpers', () => {
+  it('builds refs from stored public ids and infers raw PDFs from URLs', () => {
+    expect(
+      cloudinaryAssetsFromFields({
+        publicIds: ['ledger-bills/user-1/bill.pdf'],
+        urls: ['https://res.cloudinary.com/demo/raw/upload/v123/ledger-bills/user-1/bill.pdf'],
+      })
+    ).toEqual([
+      {
+        publicId: 'ledger-bills/user-1/bill.pdf',
+        resourceType: 'raw',
+      },
+    ]);
+  });
+
+  it('parses legacy image URLs when public ids were not persisted', () => {
+    expect(
+      cloudinaryAssetFromUrl(
+        'https://res.cloudinary.com/demo/image/upload/v123/ledger-bills/user-1/part-photo.jpg'
+      )
+    ).toEqual({
+      publicId: 'ledger-bills/user-1/part-photo',
+      resourceType: 'image',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- persist Cloudinary public IDs for inventory part and bill uploads
- delete inventory, transaction, daily cash, customer, supplier, and custom entity assets before deleting their DB records
- keep legacy URL-only inventory rows covered with Cloudinary URL parsing fallback

## Validation
- pnpm vitest run tests/api/inventory-id.test.ts tests/api/inventory.test.ts tests/api/customer-id.test.ts tests/api/transaction-id.test.ts tests/unit/cloudinary-cleanup.test.ts
- pnpm test:unit
- pnpm exec tsc --noEmit
- git diff --check

Closes #38