### PR TITLE
Add user activity dashboard

### DIFF
--- a/app/admin/usage/AdminUsageClient.tsx
+++ b/app/admin/usage/AdminUsageClient.tsx
@@ -380,16 +380,16 @@ export default function AdminUsageClient() {
           </div>
         </CardHeader>
         <CardContent className="px-0">
-          <Table>
+          <Table className="min-w-[1080px] table-fixed">
             <TableHeader>
               <TableRow className="bg-gray-50">
-                <TableHead className="px-4">User</TableHead>
-                <TableHead>Email</TableHead>
-                <TableHead>Created</TableHead>
-                <TableHead>Last Login</TableHead>
-                <TableHead>Last Active</TableHead>
-                <TableHead className="text-right">Logins</TableHead>
-                <TableHead className="px-4">Status</TableHead>
+                <TableHead className="w-[190px] px-4">User</TableHead>
+                <TableHead className="w-[240px]">Email</TableHead>
+                <TableHead className="w-[165px]">Created</TableHead>
+                <TableHead className="w-[165px]">Last Login</TableHead>
+                <TableHead className="w-[165px]">Last Active</TableHead>
+                <TableHead className="w-[90px] text-right">Logins</TableHead>
+                <TableHead className="w-[150px] px-4">Status</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -405,9 +405,15 @@ export default function AdminUsageClient() {
                   return (
                     <TableRow key={user.id}>
                       <TableCell className="px-4 font-medium text-gray-950">
-                        {user.name}
+                        <div className="truncate" title={user.name}>
+                          {user.name}
+                        </div>
                       </TableCell>
-                      <TableCell className="text-gray-600">{user.email || '-'}</TableCell>
+                      <TableCell className="text-gray-600">
+                        <div className="truncate" title={user.email || '-'}>
+                          {user.email || '-'}
+                        </div>
+                      </TableCell>
                       <TableCell>{formatDate(user.createdAt)}</TableCell>
                       <TableCell>{formatDate(user.lastLoginAt)}</TableCell>
                       <TableCell>{formatDate(user.lastActiveAt)}</TableCell>

--- a/app/admin/usage/AdminUsageClient.tsx
+++ b/app/admin/usage/AdminUsageClient.tsx
@@ -417,19 +417,81 @@ export default function AdminUsageClient() {
           </div>
         </CardHeader>
         <CardContent className="px-0">
-          <Table className="min-w-[860px] table-fixed text-sm">
-            <TableHeader>
-              <TableRow className="bg-gray-50">
-                <TableHead className="w-[17%] px-4">User</TableHead>
-                <TableHead className="w-[23%]">Email</TableHead>
-                <TableHead className="w-[12%]">Created</TableHead>
-                <TableHead className="w-[12%]">Last Login</TableHead>
-                <TableHead className="w-[12%]">Last Active</TableHead>
-                <TableHead className="w-[8%] text-right">Logins</TableHead>
-                <TableHead className="w-[16%] px-4">Status</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
+          <div className="divide-y divide-gray-100 md:hidden">
+            {filteredUsers.length === 0 ? (
+              <div className="px-4 py-10 text-center text-sm text-gray-500">
+                No users match the current search or filter.
+              </div>
+            ) : (
+              filteredUsers.map((user) => {
+                const status = getActivityStatus(user);
+                return (
+                  <div key={user.id} className="space-y-4 px-4 py-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate font-semibold text-gray-950" title={user.name}>
+                          {user.name}
+                        </p>
+                        <p className="truncate text-sm text-gray-500" title={user.email || '-'}>
+                          {user.email || '-'}
+                        </p>
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className={`shrink-0 ${status.className}`}
+                      >
+                        {status.label}
+                      </Badge>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Created
+                        </p>
+                        <ActivityDate value={user.createdAt} />
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Logins
+                        </p>
+                        <p className="font-semibold tabular-nums text-gray-950">
+                          {user.loginCount.toLocaleString('en-IN')}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Last Login
+                        </p>
+                        <ActivityDate value={user.lastLoginAt} />
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                          Last Active
+                        </p>
+                        <ActivityDate value={user.lastActiveAt} />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          <div className="hidden md:block">
+            <Table className="min-w-[860px] table-fixed text-sm">
+              <TableHeader>
+                <TableRow className="bg-gray-50">
+                  <TableHead className="w-[17%] px-4">User</TableHead>
+                  <TableHead className="w-[23%]">Email</TableHead>
+                  <TableHead className="w-[12%]">Created</TableHead>
+                  <TableHead className="w-[12%]">Last Login</TableHead>
+                  <TableHead className="w-[12%]">Last Active</TableHead>
+                  <TableHead className="w-[8%] text-right">Logins</TableHead>
+                  <TableHead className="w-[16%] px-4">Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
               {filteredUsers.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} className="h-28 text-center text-gray-500">
@@ -472,8 +534,9 @@ export default function AdminUsageClient() {
                   );
                 })
               )}
-            </TableBody>
-          </Table>
+              </TableBody>
+            </Table>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/admin/usage/AdminUsageClient.tsx
+++ b/app/admin/usage/AdminUsageClient.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Activity,
   BarChart3,
+  ChevronLeft,
+  ChevronRight,
   Clock3,
   Search,
   ShieldAlert,
@@ -15,6 +17,7 @@ import {
   Users,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import {
@@ -25,8 +28,11 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { useDebounce } from '@/lib/hooks/useDebounce';
 
 type ActivityFilter = 'all' | '24h' | '7d' | '30d' | 'inactive';
+
+const USERS_PAGE_SIZE = 10;
 
 interface UsageUser {
   id: string;
@@ -50,6 +56,15 @@ interface AdminUsageResponse {
   stickinessRate: number;
   averageLoginCount: number;
   generatedAt: string;
+  pagination: {
+    total: number;
+    totalUsers: number;
+    page: number;
+    pageSize: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
   users: UsageUser[];
 }
 
@@ -156,6 +171,8 @@ export default function AdminUsageClient() {
   const [forbidden, setForbidden] = useState(false);
   const [search, setSearch] = useState('');
   const [activityFilter, setActivityFilter] = useState<ActivityFilter>('all');
+  const [page, setPage] = useState(1);
+  const debouncedSearch = useDebounce(search, 300);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -166,7 +183,17 @@ export default function AdminUsageClient() {
       setForbidden(false);
 
       try {
-        const response = await fetch('/api/admin/usage', {
+        const params = new URLSearchParams({
+          page: String(page),
+          limit: String(USERS_PAGE_SIZE),
+          status: activityFilter,
+        });
+        const query = debouncedSearch.trim();
+        if (query) {
+          params.set('search', query);
+        }
+
+        const response = await fetch(`/api/admin/usage?${params.toString()}`, {
           signal: controller.signal,
           cache: 'no-store',
         });
@@ -197,29 +224,9 @@ export default function AdminUsageClient() {
 
     loadUsage();
     return () => controller.abort();
-  }, [router]);
+  }, [activityFilter, debouncedSearch, page, router]);
 
-  const filteredUsers = useMemo(() => {
-    const query = search.trim().toLowerCase();
-
-    return (data?.users || []).filter((user) => {
-      const status = getActivityStatus(user);
-      const matchesFilter =
-        activityFilter === 'all' ||
-        status.filter === activityFilter ||
-        (activityFilter === '7d' && status.filter === '24h') ||
-        (activityFilter === '30d' && ['24h', '7d'].includes(status.filter));
-
-      const matchesSearch =
-        !query ||
-        user.name.toLowerCase().includes(query) ||
-        user.email.toLowerCase().includes(query);
-
-      return matchesFilter && matchesSearch;
-    });
-  }, [activityFilter, data?.users, search]);
-
-  if (loading) {
+  if (loading && !data) {
     return (
       <div className="space-y-6">
         <div className="h-8 w-64 rounded bg-gray-200 animate-pulse" />
@@ -324,6 +331,18 @@ export default function AdminUsageClient() {
     { label: 'Active 30d', value: '30d' },
     { label: 'Inactive', value: 'inactive' },
   ];
+  const users = data.users;
+  const pagination = data.pagination;
+  const firstVisibleUser =
+    pagination.total === 0 ? 0 : (pagination.page - 1) * pagination.pageSize + 1;
+  const lastVisibleUser = Math.min(pagination.page * pagination.pageSize, pagination.total);
+  const totalUsersLabel = pagination.totalUsers.toLocaleString('en-IN');
+  const listSummary =
+    pagination.total === 0
+      ? `0 users shown from ${totalUsersLabel} total`
+      : `${firstVisibleUser.toLocaleString('en-IN')}-${lastVisibleUser.toLocaleString('en-IN')} of ${pagination.total.toLocaleString('en-IN')} users shown${
+          pagination.total !== pagination.totalUsers ? ` from ${totalUsersLabel} total` : ''
+        }`;
 
   return (
     <div className="space-y-6">
@@ -384,7 +403,7 @@ export default function AdminUsageClient() {
             <div>
               <CardTitle className="text-lg">Registered Users</CardTitle>
               <p className="mt-1 text-sm text-gray-500">
-                {filteredUsers.length.toLocaleString('en-IN')} of {data.users.length.toLocaleString('en-IN')} users shown
+                {listSummary}
               </p>
             </div>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -392,7 +411,10 @@ export default function AdminUsageClient() {
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                 <Input
                   value={search}
-                  onChange={(event) => setSearch(event.target.value)}
+                  onChange={(event) => {
+                    setSearch(event.target.value);
+                    setPage(1);
+                  }}
                   placeholder="Search users"
                   className="pl-9"
                 />
@@ -402,7 +424,10 @@ export default function AdminUsageClient() {
                   <button
                     key={filter.value}
                     type="button"
-                    onClick={() => setActivityFilter(filter.value)}
+                    onClick={() => {
+                      setActivityFilter(filter.value);
+                      setPage(1);
+                    }}
                     className={`h-9 rounded-md border px-3 text-sm font-medium transition-colors ${
                       activityFilter === filter.value
                         ? 'border-slate-900 bg-slate-900 text-white'
@@ -416,14 +441,14 @@ export default function AdminUsageClient() {
             </div>
           </div>
         </CardHeader>
-        <CardContent className="px-0">
+        <CardContent className="px-0" aria-busy={loading}>
           <div className="divide-y divide-gray-100 md:hidden">
-            {filteredUsers.length === 0 ? (
+            {users.length === 0 ? (
               <div className="px-4 py-10 text-center text-sm text-gray-500">
                 No users match the current search or filter.
               </div>
             ) : (
-              filteredUsers.map((user) => {
+              users.map((user) => {
                 const status = getActivityStatus(user);
                 return (
                   <div key={user.id} className="space-y-4 px-4 py-4">
@@ -478,7 +503,7 @@ export default function AdminUsageClient() {
             )}
           </div>
 
-          <div className="hidden md:block">
+          <div className="hidden overflow-x-auto md:block">
             <Table className="min-w-[860px] table-fixed text-sm">
               <TableHeader>
                 <TableRow className="bg-gray-50">
@@ -492,14 +517,14 @@ export default function AdminUsageClient() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-              {filteredUsers.length === 0 ? (
+              {users.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={7} className="h-28 text-center text-gray-500">
                     No users match the current search or filter.
                   </TableCell>
                 </TableRow>
               ) : (
-                filteredUsers.map((user) => {
+                users.map((user) => {
                   const status = getActivityStatus(user);
                   return (
                     <TableRow key={user.id}>
@@ -537,6 +562,38 @@ export default function AdminUsageClient() {
               </TableBody>
             </Table>
           </div>
+          {pagination.totalPages > 1 && (
+            <div className="flex flex-col gap-3 border-t border-gray-100 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+              <p className="text-sm text-gray-500">
+                Page {pagination.page.toLocaleString('en-IN')} of{' '}
+                {pagination.totalPages.toLocaleString('en-IN')}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage(Math.max(1, pagination.page - 1))}
+                  disabled={loading || !pagination.hasPreviousPage}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    setPage(Math.min(pagination.totalPages, pagination.page + 1))
+                  }
+                  disabled={loading || !pagination.hasNextPage}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/app/admin/usage/AdminUsageClient.tsx
+++ b/app/admin/usage/AdminUsageClient.tsx
@@ -58,11 +58,48 @@ const dateFormatter = new Intl.DateTimeFormat('en-IN', {
   timeStyle: 'short',
 });
 
+const tableDateFormatter = new Intl.DateTimeFormat('en-IN', {
+  day: 'numeric',
+  month: 'short',
+  year: '2-digit',
+});
+
+const tableTimeFormatter = new Intl.DateTimeFormat('en-IN', {
+  hour: 'numeric',
+  minute: '2-digit',
+});
+
 function formatDate(value: string | null) {
   if (!value) return 'Never';
   const date = new Date(value);
   if (!Number.isFinite(date.getTime())) return 'Never';
   return dateFormatter.format(date);
+}
+
+function getTableDateParts(value: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return null;
+
+  return {
+    date: tableDateFormatter.format(date),
+    time: tableTimeFormatter.format(date),
+  };
+}
+
+function ActivityDate({ value }: { value: string | null }) {
+  const parts = getTableDateParts(value);
+
+  if (!parts) {
+    return <span className="text-gray-500">Never</span>;
+  }
+
+  return (
+    <span className="block leading-tight">
+      <span className="block whitespace-nowrap">{parts.date}</span>
+      <span className="block whitespace-nowrap text-xs text-gray-500">{parts.time}</span>
+    </span>
+  );
 }
 
 function getActivityAgeMs(value: string | null) {
@@ -380,16 +417,16 @@ export default function AdminUsageClient() {
           </div>
         </CardHeader>
         <CardContent className="px-0">
-          <Table className="min-w-[1080px] table-fixed">
+          <Table className="min-w-[860px] table-fixed text-sm">
             <TableHeader>
               <TableRow className="bg-gray-50">
-                <TableHead className="w-[190px] px-4">User</TableHead>
-                <TableHead className="w-[240px]">Email</TableHead>
-                <TableHead className="w-[165px]">Created</TableHead>
-                <TableHead className="w-[165px]">Last Login</TableHead>
-                <TableHead className="w-[165px]">Last Active</TableHead>
-                <TableHead className="w-[90px] text-right">Logins</TableHead>
-                <TableHead className="w-[150px] px-4">Status</TableHead>
+                <TableHead className="w-[17%] px-4">User</TableHead>
+                <TableHead className="w-[23%]">Email</TableHead>
+                <TableHead className="w-[12%]">Created</TableHead>
+                <TableHead className="w-[12%]">Last Login</TableHead>
+                <TableHead className="w-[12%]">Last Active</TableHead>
+                <TableHead className="w-[8%] text-right">Logins</TableHead>
+                <TableHead className="w-[16%] px-4">Status</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -414,13 +451,19 @@ export default function AdminUsageClient() {
                           {user.email || '-'}
                         </div>
                       </TableCell>
-                      <TableCell>{formatDate(user.createdAt)}</TableCell>
-                      <TableCell>{formatDate(user.lastLoginAt)}</TableCell>
-                      <TableCell>{formatDate(user.lastActiveAt)}</TableCell>
+                      <TableCell className="whitespace-normal">
+                        <ActivityDate value={user.createdAt} />
+                      </TableCell>
+                      <TableCell className="whitespace-normal">
+                        <ActivityDate value={user.lastLoginAt} />
+                      </TableCell>
+                      <TableCell className="whitespace-normal">
+                        <ActivityDate value={user.lastActiveAt} />
+                      </TableCell>
                       <TableCell className="text-right tabular-nums">
                         {user.loginCount.toLocaleString('en-IN')}
                       </TableCell>
-                      <TableCell className="px-4">
+                      <TableCell className="px-4 whitespace-nowrap">
                         <Badge variant="outline" className={status.className}>
                           {status.label}
                         </Badge>

--- a/app/admin/usage/AdminUsageClient.tsx
+++ b/app/admin/usage/AdminUsageClient.tsx
@@ -1,0 +1,432 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Activity,
+  BarChart3,
+  Clock3,
+  Search,
+  ShieldAlert,
+  TrendingUp,
+  UserPlus,
+  UserRoundCheck,
+  UserRoundX,
+  Users,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+type ActivityFilter = 'all' | '24h' | '7d' | '30d' | 'inactive';
+
+interface UsageUser {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string | null;
+  lastLoginAt: string | null;
+  lastActiveAt: string | null;
+  loginCount: number;
+}
+
+interface AdminUsageResponse {
+  totalUsers: number;
+  activeLast24Hours: number;
+  activeLast7Days: number;
+  activeLast30Days: number;
+  newUsersLast7Days: number;
+  inactive30PlusDays: number;
+  activeRateLast7Days: number;
+  activeRateLast30Days: number;
+  stickinessRate: number;
+  averageLoginCount: number;
+  generatedAt: string;
+  users: UsageUser[];
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en-IN', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+function formatDate(value: string | null) {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return 'Never';
+  return dateFormatter.format(date);
+}
+
+function getActivityAgeMs(value: string | null) {
+  if (!value) return Number.POSITIVE_INFINITY;
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return Number.POSITIVE_INFINITY;
+  return Date.now() - date.getTime();
+}
+
+function getActivityStatus(user: UsageUser) {
+  const ageMs = getActivityAgeMs(user.lastActiveAt);
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  if (ageMs <= dayMs) {
+    return {
+      label: 'Active 24h',
+      filter: '24h' as const,
+      className: 'border-green-200 bg-green-50 text-green-700',
+    };
+  }
+
+  if (ageMs <= 7 * dayMs) {
+    return {
+      label: 'Active 7d',
+      filter: '7d' as const,
+      className: 'border-blue-200 bg-blue-50 text-blue-700',
+    };
+  }
+
+  if (ageMs <= 30 * dayMs) {
+    return {
+      label: 'Active 30d',
+      filter: '30d' as const,
+      className: 'border-amber-200 bg-amber-50 text-amber-700',
+    };
+  }
+
+  return {
+    label: 'Inactive',
+    filter: 'inactive' as const,
+    className: 'border-gray-200 bg-gray-50 text-gray-600',
+  };
+}
+
+function metricValue(value: number, suffix = '') {
+  return `${Number.isFinite(value) ? value.toLocaleString('en-IN') : '0'}${suffix}`;
+}
+
+export default function AdminUsageClient() {
+  const router = useRouter();
+  const [data, setData] = useState<AdminUsageResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [forbidden, setForbidden] = useState(false);
+  const [search, setSearch] = useState('');
+  const [activityFilter, setActivityFilter] = useState<ActivityFilter>('all');
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadUsage() {
+      setLoading(true);
+      setError(null);
+      setForbidden(false);
+
+      try {
+        const response = await fetch('/api/admin/usage', {
+          signal: controller.signal,
+          cache: 'no-store',
+        });
+
+        if (response.status === 401) {
+          router.push('/login');
+          return;
+        }
+
+        if (response.status === 403) {
+          setForbidden(true);
+          return;
+        }
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => null);
+          throw new Error(body?.error || 'Failed to load user activity');
+        }
+
+        setData(await response.json());
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : 'Failed to load user activity');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadUsage();
+    return () => controller.abort();
+  }, [router]);
+
+  const filteredUsers = useMemo(() => {
+    const query = search.trim().toLowerCase();
+
+    return (data?.users || []).filter((user) => {
+      const status = getActivityStatus(user);
+      const matchesFilter =
+        activityFilter === 'all' ||
+        status.filter === activityFilter ||
+        (activityFilter === '7d' && status.filter === '24h') ||
+        (activityFilter === '30d' && ['24h', '7d'].includes(status.filter));
+
+      const matchesSearch =
+        !query ||
+        user.name.toLowerCase().includes(query) ||
+        user.email.toLowerCase().includes(query);
+
+      return matchesFilter && matchesSearch;
+    });
+  }, [activityFilter, data?.users, search]);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <div className="h-8 w-64 rounded bg-gray-200 animate-pulse" />
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="h-32 rounded-xl bg-gray-200 animate-pulse" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (forbidden) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="max-w-md rounded-xl border border-red-200 bg-red-50 p-6 text-center">
+          <ShieldAlert className="mx-auto h-10 w-10 text-red-600" />
+          <h1 className="mt-4 text-xl font-bold text-red-900">Admin access required</h1>
+          <p className="mt-2 text-sm text-red-700">
+            Your logged-in email is not listed in the admin allow-list for this deployment.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+        <h1 className="text-xl font-bold text-red-900">Unable to load user activity</h1>
+        <p className="mt-2 text-sm text-red-700">{error || 'Please try again.'}</p>
+      </div>
+    );
+  }
+
+  const metrics = [
+    {
+      label: 'Total Users',
+      value: metricValue(data.totalUsers),
+      icon: Users,
+      className: 'bg-slate-50 text-slate-700 border-slate-200',
+    },
+    {
+      label: 'Active Last 24 Hours',
+      value: metricValue(data.activeLast24Hours),
+      icon: Activity,
+      className: 'bg-green-50 text-green-700 border-green-200',
+    },
+    {
+      label: 'Active Last 7 Days',
+      value: metricValue(data.activeLast7Days),
+      icon: UserRoundCheck,
+      className: 'bg-blue-50 text-blue-700 border-blue-200',
+    },
+    {
+      label: 'Active Last 30 Days',
+      value: metricValue(data.activeLast30Days),
+      icon: BarChart3,
+      className: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+    },
+    {
+      label: 'New Users Last 7 Days',
+      value: metricValue(data.newUsersLast7Days),
+      icon: UserPlus,
+      className: 'bg-cyan-50 text-cyan-700 border-cyan-200',
+    },
+    {
+      label: 'Inactive 30+ Days',
+      value: metricValue(data.inactive30PlusDays),
+      icon: UserRoundX,
+      className: 'bg-amber-50 text-amber-700 border-amber-200',
+    },
+  ];
+
+  const insights = [
+    {
+      label: '7-Day Active Rate',
+      value: metricValue(data.activeRateLast7Days, '%'),
+      icon: TrendingUp,
+    },
+    {
+      label: '30-Day Active Rate',
+      value: metricValue(data.activeRateLast30Days, '%'),
+      icon: TrendingUp,
+    },
+    {
+      label: 'Stickiness',
+      value: metricValue(data.stickinessRate, '%'),
+      icon: Clock3,
+    },
+    {
+      label: 'Avg Login Count',
+      value: metricValue(data.averageLoginCount),
+      icon: Users,
+    },
+  ];
+
+  const filters: Array<{ label: string; value: ActivityFilter }> = [
+    { label: 'All', value: 'all' },
+    { label: 'Active 24h', value: '24h' },
+    { label: 'Active 7d', value: '7d' },
+    { label: 'Active 30d', value: '30d' },
+    { label: 'Inactive', value: 'inactive' },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-blue-700">
+            Admin Analytics
+          </p>
+          <h1 className="mt-1 text-2xl font-bold text-gray-950 sm:text-3xl">
+            User Activity Dashboard
+          </h1>
+        </div>
+        <p className="text-sm text-gray-500">
+          Updated {formatDate(data.generatedAt)}
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {metrics.map((metric) => {
+          const Icon = metric.icon;
+          return (
+            <Card key={metric.label} className={`border p-5 ${metric.className}`}>
+              <div className="flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium opacity-80">{metric.label}</p>
+                  <p className="mt-2 text-3xl font-bold tracking-normal">{metric.value}</p>
+                </div>
+                <Icon className="h-8 w-8 shrink-0 opacity-80" />
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        {insights.map((insight) => {
+          const Icon = insight.icon;
+          return (
+            <div
+              key={insight.label}
+              className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+            >
+              <div className="flex items-center gap-2 text-gray-500">
+                <Icon className="h-4 w-4" />
+                <span className="text-xs font-semibold uppercase tracking-wide">
+                  {insight.label}
+                </span>
+              </div>
+              <p className="mt-2 text-2xl font-bold text-gray-950">{insight.value}</p>
+            </div>
+          );
+        })}
+      </div>
+
+      <Card className="overflow-hidden border-gray-200 bg-white py-0">
+        <CardHeader className="border-b border-gray-100 px-4 py-4 sm:px-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <CardTitle className="text-lg">Registered Users</CardTitle>
+              <p className="mt-1 text-sm text-gray-500">
+                {filteredUsers.length.toLocaleString('en-IN')} of {data.users.length.toLocaleString('en-IN')} users shown
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <div className="relative min-w-0 sm:w-72">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                <Input
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                  placeholder="Search users"
+                  className="pl-9"
+                />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {filters.map((filter) => (
+                  <button
+                    key={filter.value}
+                    type="button"
+                    onClick={() => setActivityFilter(filter.value)}
+                    className={`h-9 rounded-md border px-3 text-sm font-medium transition-colors ${
+                      activityFilter === filter.value
+                        ? 'border-slate-900 bg-slate-900 text-white'
+                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    {filter.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="px-0">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-gray-50">
+                <TableHead className="px-4">User</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Last Login</TableHead>
+                <TableHead>Last Active</TableHead>
+                <TableHead className="text-right">Logins</TableHead>
+                <TableHead className="px-4">Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredUsers.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="h-28 text-center text-gray-500">
+                    No users match the current search or filter.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filteredUsers.map((user) => {
+                  const status = getActivityStatus(user);
+                  return (
+                    <TableRow key={user.id}>
+                      <TableCell className="px-4 font-medium text-gray-950">
+                        {user.name}
+                      </TableCell>
+                      <TableCell className="text-gray-600">{user.email || '-'}</TableCell>
+                      <TableCell>{formatDate(user.createdAt)}</TableCell>
+                      <TableCell>{formatDate(user.lastLoginAt)}</TableCell>
+                      <TableCell>{formatDate(user.lastActiveAt)}</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {user.loginCount.toLocaleString('en-IN')}
+                      </TableCell>
+                      <TableCell className="px-4">
+                        <Badge variant="outline" className={status.className}>
+                          {status.label}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/usage/page.tsx
+++ b/app/admin/usage/page.tsx
@@ -1,0 +1,8 @@
+import AdminUsageClient from './AdminUsageClient';
+
+export const revalidate = 0;
+export const dynamic = 'force-dynamic';
+
+export default function AdminUsagePage() {
+  return <AdminUsageClient />;
+}

--- a/app/api/admin/usage/route.ts
+++ b/app/api/admin/usage/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ObjectId } from 'mongodb';
+import { ObjectId, type Document, type Filter } from 'mongodb';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import { isAdminEmail } from '@/lib/admin';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 100;
+const ACTIVITY_FILTERS = ['all', '24h', '7d', '30d', 'inactive'] as const;
+
+type ActivityFilter = (typeof ACTIVITY_FILTERS)[number];
 
 function toIsoStringOrNull(value: unknown) {
   if (!value) return null;
@@ -19,6 +24,86 @@ function toNumber(value: unknown) {
 function toPercent(value: number, total: number) {
   if (total <= 0) return 0;
   return Math.round((value / total) * 1000) / 10;
+}
+
+function parsePositiveInteger(value: string | null, fallback: number, max = Number.POSITIVE_INFINITY) {
+  const parsed = Number(value);
+  if (!value || !Number.isInteger(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, max);
+}
+
+function getActivityFilter(value: string | null): ActivityFilter {
+  if (ACTIVITY_FILTERS.includes(value as ActivityFilter)) {
+    return value as ActivityFilter;
+  }
+
+  return 'all';
+}
+
+function escapeRegex(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildStatusFilter(
+  status: ActivityFilter,
+  last24Hours: Date,
+  last7Days: Date,
+  last30Days: Date
+): Filter<Document> | null {
+  switch (status) {
+    case '24h':
+      return { lastActiveAt: { $gte: last24Hours } };
+    case '7d':
+      return { lastActiveAt: { $gte: last7Days } };
+    case '30d':
+      return { lastActiveAt: { $gte: last30Days } };
+    case 'inactive':
+      return {
+        $or: [
+          { lastActiveAt: { $lt: last30Days } },
+          { lastActiveAt: { $exists: false } },
+          { lastActiveAt: null },
+        ],
+      };
+    default:
+      return null;
+  }
+}
+
+function buildUsersFilter({
+  search,
+  status,
+  last24Hours,
+  last7Days,
+  last30Days,
+}: {
+  search: string;
+  status: ActivityFilter;
+  last24Hours: Date;
+  last7Days: Date;
+  last30Days: Date;
+}): Filter<Document> {
+  const filters: Filter<Document>[] = [];
+
+  if (search) {
+    const searchRegex = new RegExp(escapeRegex(search), 'i');
+    filters.push({
+      $or: [
+        { name: searchRegex },
+        { email: searchRegex },
+      ],
+    });
+  }
+
+  const statusFilter = buildStatusFilter(status, last24Hours, last7Days, last30Days);
+  if (statusFilter) {
+    filters.push(statusFilter);
+  }
+
+  if (filters.length === 0) return {};
+  if (filters.length === 1) return filters[0];
+
+  return { $and: filters };
 }
 
 export async function GET(request: NextRequest) {
@@ -48,6 +133,21 @@ export async function GET(request: NextRequest) {
     const last24Hours = new Date(now.getTime() - DAY_MS);
     const last7Days = new Date(now.getTime() - 7 * DAY_MS);
     const last30Days = new Date(now.getTime() - 30 * DAY_MS);
+    const page = parsePositiveInteger(request.nextUrl.searchParams.get('page'), 1);
+    const limit = parsePositiveInteger(
+      request.nextUrl.searchParams.get('limit'),
+      DEFAULT_PAGE_SIZE,
+      MAX_PAGE_SIZE
+    );
+    const search = (request.nextUrl.searchParams.get('search') || '').trim();
+    const status = getActivityFilter(request.nextUrl.searchParams.get('status'));
+    const usersFilter = buildUsersFilter({
+      search,
+      status,
+      last24Hours,
+      last7Days,
+      last30Days,
+    });
 
     const [
       totalUsers,
@@ -56,7 +156,7 @@ export async function GET(request: NextRequest) {
       activeLast30Days,
       newUsersLast7Days,
       inactive30PlusDays,
-      users,
+      filteredUsers,
     ] = await Promise.all([
       usersCollection.countDocuments({}),
       usersCollection.countDocuments({ lastActiveAt: { $gte: last24Hours } }),
@@ -70,9 +170,25 @@ export async function GET(request: NextRequest) {
           { lastActiveAt: null },
         ],
       }),
+      usersCollection.countDocuments(usersFilter),
+    ]);
+
+    const totalPages = Math.max(1, Math.ceil(filteredUsers / limit));
+    const currentPage = Math.min(page, totalPages);
+    const skip = (currentPage - 1) * limit;
+
+    const [loginStats, users] = await Promise.all([
+      usersCollection.aggregate([
+        {
+          $group: {
+            _id: null,
+            totalLoginCount: { $sum: { $ifNull: ['$loginCount', 0] } },
+          },
+        },
+      ]).toArray(),
       usersCollection
         .find(
-          {},
+          usersFilter,
           {
             projection: {
               password: 0,
@@ -80,10 +196,12 @@ export async function GET(request: NextRequest) {
           }
         )
         .sort({ lastActiveAt: -1, createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
         .toArray(),
     ]);
 
-    const totalLoginCount = users.reduce((sum, user) => sum + toNumber(user.loginCount), 0);
+    const totalLoginCount = toNumber(loginStats[0]?.totalLoginCount);
     const averageLoginCount = totalUsers > 0 ? Math.round((totalLoginCount / totalUsers) * 10) / 10 : 0;
 
     return NextResponse.json({
@@ -98,6 +216,15 @@ export async function GET(request: NextRequest) {
       stickinessRate: toPercent(activeLast24Hours, activeLast30Days),
       averageLoginCount,
       generatedAt: now.toISOString(),
+      pagination: {
+        total: filteredUsers,
+        totalUsers,
+        page: currentPage,
+        pageSize: limit,
+        totalPages,
+        hasNextPage: currentPage < totalPages,
+        hasPreviousPage: currentPage > 1,
+      },
       users: users.map((user) => ({
         id: user._id.toString(),
         name: user.name || 'Unnamed user',

--- a/app/api/admin/usage/route.ts
+++ b/app/api/admin/usage/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ObjectId } from 'mongodb';
+import { getDb } from '@/lib/mongodb';
+import { getUserIdFromRequest } from '@/lib/auth';
+import { isAdminEmail } from '@/lib/admin';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toIsoStringOrNull(value: unknown) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+function toNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function toPercent(value: number, total: number) {
+  if (total <= 0) return 0;
+  return Math.round((value / total) * 1000) / 10;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const userId = getUserIdFromRequest(request);
+
+    if (!userId || !ObjectId.isValid(userId)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const db = await getDb();
+    const usersCollection = db.collection('users');
+    const requester = await usersCollection.findOne(
+      { _id: new ObjectId(userId) },
+      { projection: { email: 1 } }
+    );
+
+    if (!requester) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!isAdminEmail(requester.email)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const now = new Date();
+    const last24Hours = new Date(now.getTime() - DAY_MS);
+    const last7Days = new Date(now.getTime() - 7 * DAY_MS);
+    const last30Days = new Date(now.getTime() - 30 * DAY_MS);
+
+    const [
+      totalUsers,
+      activeLast24Hours,
+      activeLast7Days,
+      activeLast30Days,
+      newUsersLast7Days,
+      inactive30PlusDays,
+      users,
+    ] = await Promise.all([
+      usersCollection.countDocuments({}),
+      usersCollection.countDocuments({ lastActiveAt: { $gte: last24Hours } }),
+      usersCollection.countDocuments({ lastActiveAt: { $gte: last7Days } }),
+      usersCollection.countDocuments({ lastActiveAt: { $gte: last30Days } }),
+      usersCollection.countDocuments({ createdAt: { $gte: last7Days } }),
+      usersCollection.countDocuments({
+        $or: [
+          { lastActiveAt: { $lt: last30Days } },
+          { lastActiveAt: { $exists: false } },
+          { lastActiveAt: null },
+        ],
+      }),
+      usersCollection
+        .find(
+          {},
+          {
+            projection: {
+              password: 0,
+            },
+          }
+        )
+        .sort({ lastActiveAt: -1, createdAt: -1 })
+        .toArray(),
+    ]);
+
+    const totalLoginCount = users.reduce((sum, user) => sum + toNumber(user.loginCount), 0);
+    const averageLoginCount = totalUsers > 0 ? Math.round((totalLoginCount / totalUsers) * 10) / 10 : 0;
+
+    return NextResponse.json({
+      totalUsers,
+      activeLast24Hours,
+      activeLast7Days,
+      activeLast30Days,
+      newUsersLast7Days,
+      inactive30PlusDays,
+      activeRateLast7Days: toPercent(activeLast7Days, totalUsers),
+      activeRateLast30Days: toPercent(activeLast30Days, totalUsers),
+      stickinessRate: toPercent(activeLast24Hours, activeLast30Days),
+      averageLoginCount,
+      generatedAt: now.toISOString(),
+      users: users.map((user) => ({
+        id: user._id.toString(),
+        name: user.name || 'Unnamed user',
+        email: user.email || '',
+        createdAt: toIsoStringOrNull(user.createdAt),
+        lastLoginAt: toIsoStringOrNull(user.lastLoginAt),
+        lastActiveAt: toIsoStringOrNull(user.lastActiveAt),
+        loginCount: toNumber(user.loginCount),
+      })),
+    });
+  } catch (error) {
+    console.error('Get admin usage error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -46,6 +46,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const now = new Date();
+    await usersCollection.updateOne(
+      { _id: user._id },
+      {
+        $set: {
+          lastLoginAt: now,
+          lastActiveAt: now,
+        },
+        $inc: {
+          loginCount: 1,
+        },
+      }
+    );
+
     const token = generateToken({
       userId: user._id.toString(),
       email: user.email,
@@ -87,4 +101,3 @@ export async function POST(request: NextRequest) {
     );
   }
 }
-

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
+import { isAdminEmail } from '@/lib/admin';
 import { z } from 'zod';
+
+const LAST_ACTIVE_WRITE_INTERVAL_MS = 15 * 60 * 1000;
 
 const updateProfileSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters'),
@@ -39,11 +42,26 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const lastActiveAt = user.lastActiveAt ? new Date(user.lastActiveAt) : null;
+    const now = new Date();
+    const shouldUpdateLastActive =
+      !lastActiveAt ||
+      !Number.isFinite(lastActiveAt.getTime()) ||
+      now.getTime() - lastActiveAt.getTime() >= LAST_ACTIVE_WRITE_INTERVAL_MS;
+
+    if (shouldUpdateLastActive) {
+      await usersCollection.updateOne(
+        { _id: new ObjectId(userId) },
+        { $set: { lastActiveAt: now } }
+      );
+    }
+
     return NextResponse.json({
       user: {
         id: user._id.toString(),
         name: user.name,
         email: user.email,
+        isAdmin: isAdminEmail(user.email),
         firmTitle: user.firmTitle || '',
         gstNumber: user.gstNumber || '',
         firmPhone: user.firmPhone || '',
@@ -112,6 +130,7 @@ export async function PUT(request: NextRequest) {
         id: updatedUser!._id.toString(),
         name: updatedUser!.name,
         email: updatedUser!.email,
+        isAdmin: isAdminEmail(updatedUser!.email),
         firmTitle: updatedUser!.firmTitle || '',
         gstNumber: updatedUser!.gstNumber || '',
         firmPhone: updatedUser!.firmPhone || '',
@@ -134,4 +153,3 @@ export async function PUT(request: NextRequest) {
     );
   }
 }
-

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -20,7 +20,8 @@ import {
   User,
   FileText,
   Settings,
-  Boxes
+  Boxes,
+  Activity
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -38,7 +39,7 @@ type SidebarProps = {
 export default function Sidebar({ collapsed = false }: SidebarProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const [user, setUser] = useState<{ name: string; email: string } | null>(null);
+  const [user, setUser] = useState<{ name: string; email: string; isAdmin?: boolean } | null>(null);
   const [loading, setLoading] = useState(true);
   const lastPathnameRef = useRef<string>('');
   const [isMobileOpen, setIsMobileOpen] = useState(false);
@@ -154,16 +155,28 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
     router.refresh();
   }, [router]);
 
-  const navLinks = useMemo(() => [
-    { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { href: '/customers', label: 'Customers', icon: Users },
-    { href: '/suppliers', label: 'Suppliers', icon: Building2 },
-    { href: '/transactions/new', label: 'New Transaction', icon: PlusCircle },
-    { href: '/invoices', label: 'Invoices', icon: FileText },
-    { href: '/inventory', label: 'Inventory', icon: Boxes },
-    { href: '/daily-cash-record', label: 'Cash Record', icon: Wallet },
-    { href: '/notes', label: 'Notes', icon: StickyNote },
-  ], []);
+  const navLinks = useMemo(() => {
+    const links = [
+      { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+      { href: '/customers', label: 'Customers', icon: Users },
+      { href: '/suppliers', label: 'Suppliers', icon: Building2 },
+      { href: '/transactions/new', label: 'New Transaction', icon: PlusCircle },
+      { href: '/invoices', label: 'Invoices', icon: FileText },
+      { href: '/inventory', label: 'Inventory', icon: Boxes },
+      { href: '/daily-cash-record', label: 'Cash Record', icon: Wallet },
+      { href: '/notes', label: 'Notes', icon: StickyNote },
+    ];
+
+    if (user?.isAdmin) {
+      links.push({
+        href: '/admin/usage',
+        label: 'User Activity Dashboard',
+        icon: Activity,
+      });
+    }
+
+    return links;
+  }, [user?.isAdmin]);
 
   const isActive = useCallback((href: string) => {
     if (href === '/dashboard') {
@@ -228,7 +241,7 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
               }`}
             >
               <Icon className={`h-5 w-5 ${active ? 'text-blue-600' : 'text-gray-500'}`} />
-              {!effectiveCollapsed && <span>{link.label}</span>}
+              {!effectiveCollapsed && <span className="truncate">{link.label}</span>}
               {effectiveCollapsed && <span className="sr-only">{link.label}</span>}
             </Link>
           );

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,0 +1,13 @@
+export function getAdminEmails(value = process.env.ADMIN_EMAILS) {
+  return new Set(
+    (value || '')
+      .split(',')
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+export function isAdminEmail(email?: string | null, adminEmails = process.env.ADMIN_EMAILS) {
+  if (!email) return false;
+  return getAdminEmails(adminEmails).has(email.trim().toLowerCase());
+}

--- a/lib/db-indexes.ts
+++ b/lib/db-indexes.ts
@@ -36,6 +36,8 @@ export async function initializeIndexes(db: Db): Promise<void> {
 
       users.createIndex({ email: 1 }, { unique: true }),
       users.createIndex({ userId: 1 }),
+      users.createIndex({ lastActiveAt: -1 }),
+      users.createIndex({ lastLoginAt: -1 }),
 
       collectionTypes.createIndex({ userId: 1, slug: 1 }, { unique: true }),
       collectionTypes.createIndex({ userId: 1, createdAt: -1 }),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,6 +8,9 @@ export interface User {
   firmPhone?: string;
   firmEmail?: string;
   firmAddress?: string;
+  lastLoginAt?: Date;
+  lastActiveAt?: Date;
+  loginCount?: number;
   createdAt: Date;
 }
 

--- a/tests/api/admin-usage.test.ts
+++ b/tests/api/admin-usage.test.ts
@@ -76,20 +76,25 @@ describe('/api/admin/usage', () => {
       .mockResolvedValueOnce(1)
       .mockResolvedValueOnce(1)
       .mockResolvedValueOnce(0)
-      .mockResolvedValueOnce(1);
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(2);
     const findOne = vi.fn().mockResolvedValue({ email: 'admin@example.com' });
     const toArray = vi.fn().mockResolvedValue(users);
-    const sort = vi.fn(() => ({ toArray }));
+    const limit = vi.fn(() => ({ toArray }));
+    const skip = vi.fn(() => ({ limit }));
+    const sort = vi.fn(() => ({ skip }));
     const find = vi.fn(() => ({ sort }));
+    const aggregateToArray = vi.fn().mockResolvedValue([{ totalLoginCount: 5 }]);
+    const aggregate = vi.fn(() => ({ toArray: aggregateToArray }));
     mocks.getDb.mockResolvedValue({
-      collection: vi.fn(() => ({ findOne, countDocuments, find })),
+      collection: vi.fn(() => ({ findOne, countDocuments, aggregate, find })),
     });
 
     const { GET } = await import('@/app/api/admin/usage/route');
     const response = await GET(jsonRequest('http://localhost/api/admin/usage'));
 
     expect(response.status).toBe(200);
-    expect(countDocuments).toHaveBeenCalledTimes(6);
+    expect(countDocuments).toHaveBeenCalledTimes(7);
     expect(find).toHaveBeenCalledWith(
       {},
       {
@@ -98,7 +103,17 @@ describe('/api/admin/usage', () => {
         },
       }
     );
+    expect(aggregate).toHaveBeenCalledWith([
+      {
+        $group: {
+          _id: null,
+          totalLoginCount: { $sum: { $ifNull: ['$loginCount', 0] } },
+        },
+      },
+    ]);
     expect(sort).toHaveBeenCalledWith({ lastActiveAt: -1, createdAt: -1 });
+    expect(skip).toHaveBeenCalledWith(0);
+    expect(limit).toHaveBeenCalledWith(10);
     await expect(response.json()).resolves.toMatchObject({
       totalUsers: 2,
       activeLast24Hours: 1,
@@ -110,6 +125,15 @@ describe('/api/admin/usage', () => {
       activeRateLast30Days: 50,
       stickinessRate: 100,
       averageLoginCount: 2.5,
+      pagination: {
+        total: 2,
+        totalUsers: 2,
+        page: 1,
+        pageSize: 10,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      },
       users: [
         {
           id: ids.user,
@@ -120,6 +144,96 @@ describe('/api/admin/usage', () => {
           lastActiveAt: '2026-07-02T03:00:00.000Z',
           loginCount: 5,
         },
+        {
+          name: 'Quiet User',
+          email: 'quiet@example.com',
+          lastLoginAt: null,
+          lastActiveAt: null,
+          loginCount: 0,
+        },
+      ],
+    });
+  });
+
+  it('paginates and filters admin user rows from query params', async () => {
+    mocks.getUserIdFromRequest.mockReturnValue(ids.user);
+    const users = [
+      {
+        _id: objectIdLike('507f1f77bcf86cd799439020'),
+        name: 'Quiet User',
+        email: 'quiet@example.com',
+        createdAt: new Date('2026-05-01T10:00:00.000Z'),
+        lastLoginAt: null,
+        lastActiveAt: null,
+        loginCount: 0,
+      },
+    ];
+    const countDocuments = vi
+      .fn()
+      .mockResolvedValueOnce(15)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(8)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(7)
+      .mockResolvedValueOnce(7);
+    const findOne = vi.fn().mockResolvedValue({ email: 'admin@example.com' });
+    const toArray = vi.fn().mockResolvedValue(users);
+    const limit = vi.fn(() => ({ toArray }));
+    const skip = vi.fn(() => ({ limit }));
+    const sort = vi.fn(() => ({ skip }));
+    const find = vi.fn(() => ({ sort }));
+    const aggregate = vi.fn(() => ({
+      toArray: vi.fn().mockResolvedValue([{ totalLoginCount: 30 }]),
+    }));
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne, countDocuments, aggregate, find })),
+    });
+
+    const { GET } = await import('@/app/api/admin/usage/route');
+    const response = await GET(
+      jsonRequest('http://localhost/api/admin/usage?search=quiet&status=inactive&page=2&limit=5')
+    );
+
+    const findCalls = find.mock.calls as unknown[][];
+    const countDocumentCalls = countDocuments.mock.calls as unknown[][];
+    const filter = findCalls[0]?.[0] as {
+      $and: Array<{
+        $or: Array<{
+          name?: RegExp;
+          lastActiveAt?: unknown;
+        }>;
+      }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(countDocuments).toHaveBeenCalledTimes(7);
+    expect(countDocumentCalls[6]?.[0]).toBe(filter);
+    expect(filter.$and).toHaveLength(2);
+    const searchRegex = filter.$and[0]?.$or[0]?.name;
+    expect(searchRegex).toBeInstanceOf(RegExp);
+    expect(searchRegex?.test('Quiet User')).toBe(true);
+    expect(filter.$and[1]?.$or).toEqual(
+      expect.arrayContaining([
+        { lastActiveAt: { $exists: false } },
+        { lastActiveAt: null },
+      ])
+    );
+    expect(skip).toHaveBeenCalledWith(5);
+    expect(limit).toHaveBeenCalledWith(5);
+    await expect(response.json()).resolves.toMatchObject({
+      totalUsers: 15,
+      averageLoginCount: 2,
+      pagination: {
+        total: 7,
+        totalUsers: 15,
+        page: 2,
+        pageSize: 5,
+        totalPages: 2,
+        hasNextPage: false,
+        hasPreviousPage: true,
+      },
+      users: [
         {
           name: 'Quiet User',
           email: 'quiet@example.com',

--- a/tests/api/admin-usage.test.ts
+++ b/tests/api/admin-usage.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ids, jsonRequest, objectIdLike } from '@/tests/helpers/api';
+
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  getUserIdFromRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getUserIdFromRequest: mocks.getUserIdFromRequest,
+}));
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: mocks.getDb,
+}));
+
+describe('/api/admin/usage', () => {
+  beforeEach(() => {
+    mocks.getDb.mockReset();
+    mocks.getUserIdFromRequest.mockReset();
+    process.env.ADMIN_EMAILS = 'admin@example.com';
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    mocks.getUserIdFromRequest.mockReturnValue(null);
+
+    const { GET } = await import('@/app/api/admin/usage/route');
+    const response = await GET(jsonRequest('http://localhost/api/admin/usage'));
+
+    expect(response.status).toBe(401);
+    expect(mocks.getDb).not.toHaveBeenCalled();
+  });
+
+  it('rejects authenticated non-admin users', async () => {
+    mocks.getUserIdFromRequest.mockReturnValue(ids.user);
+    const countDocuments = vi.fn();
+    const findOne = vi.fn().mockResolvedValue({ email: 'owner@example.com' });
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne, countDocuments })),
+    });
+
+    const { GET } = await import('@/app/api/admin/usage/route');
+    const response = await GET(jsonRequest('http://localhost/api/admin/usage'));
+
+    expect(response.status).toBe(403);
+    expect(findOne).toHaveBeenCalledWith(
+      { _id: expect.any(Object) },
+      { projection: { email: 1 } }
+    );
+    expect(countDocuments).not.toHaveBeenCalled();
+  });
+
+  it('returns usage metrics and normalized user rows for admins', async () => {
+    mocks.getUserIdFromRequest.mockReturnValue(ids.user);
+    const users = [
+      {
+        _id: objectIdLike(ids.user),
+        name: 'Admin User',
+        email: 'admin@example.com',
+        createdAt: new Date('2026-06-01T10:00:00.000Z'),
+        lastLoginAt: new Date('2026-07-01T10:00:00.000Z'),
+        lastActiveAt: new Date('2026-07-02T03:00:00.000Z'),
+        loginCount: 5,
+      },
+      {
+        _id: objectIdLike('507f1f77bcf86cd799439020'),
+        name: 'Quiet User',
+        email: 'quiet@example.com',
+        createdAt: new Date('2026-05-01T10:00:00.000Z'),
+      },
+    ];
+    const countDocuments = vi
+      .fn()
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1);
+    const findOne = vi.fn().mockResolvedValue({ email: 'admin@example.com' });
+    const toArray = vi.fn().mockResolvedValue(users);
+    const sort = vi.fn(() => ({ toArray }));
+    const find = vi.fn(() => ({ sort }));
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne, countDocuments, find })),
+    });
+
+    const { GET } = await import('@/app/api/admin/usage/route');
+    const response = await GET(jsonRequest('http://localhost/api/admin/usage'));
+
+    expect(response.status).toBe(200);
+    expect(countDocuments).toHaveBeenCalledTimes(6);
+    expect(find).toHaveBeenCalledWith(
+      {},
+      {
+        projection: {
+          password: 0,
+        },
+      }
+    );
+    expect(sort).toHaveBeenCalledWith({ lastActiveAt: -1, createdAt: -1 });
+    await expect(response.json()).resolves.toMatchObject({
+      totalUsers: 2,
+      activeLast24Hours: 1,
+      activeLast7Days: 1,
+      activeLast30Days: 1,
+      newUsersLast7Days: 0,
+      inactive30PlusDays: 1,
+      activeRateLast7Days: 50,
+      activeRateLast30Days: 50,
+      stickinessRate: 100,
+      averageLoginCount: 2.5,
+      users: [
+        {
+          id: ids.user,
+          name: 'Admin User',
+          email: 'admin@example.com',
+          createdAt: '2026-06-01T10:00:00.000Z',
+          lastLoginAt: '2026-07-01T10:00:00.000Z',
+          lastActiveAt: '2026-07-02T03:00:00.000Z',
+          loginCount: 5,
+        },
+        {
+          name: 'Quiet User',
+          email: 'quiet@example.com',
+          lastLoginAt: null,
+          lastActiveAt: null,
+          loginCount: 0,
+        },
+      ],
+    });
+  });
+});

--- a/tests/api/auth-login.test.ts
+++ b/tests/api/auth-login.test.ts
@@ -89,6 +89,7 @@ describe('POST /api/auth/login', () => {
   });
 
   it('logs in valid users and sets the token cookie', async () => {
+    const updateOne = vi.fn().mockResolvedValue({ modifiedCount: 1 });
     const findOne = vi.fn().mockResolvedValue({
       _id: { toString: () => 'user-1' },
       name: 'Shop Owner',
@@ -98,6 +99,7 @@ describe('POST /api/auth/login', () => {
     mocks.getDb.mockResolvedValue({
       collection: vi.fn(() => ({
         findOne,
+        updateOne,
       })),
     });
     mocks.compare.mockResolvedValue(true);
@@ -111,6 +113,18 @@ describe('POST /api/auth/login', () => {
     expect(response.status).toBe(200);
     expect(findOne).toHaveBeenCalledWith({ email: 'owner@example.com' });
     expect(mocks.compare).toHaveBeenCalledWith('secret', 'hashed-password');
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: expect.any(Object) },
+      {
+        $set: {
+          lastLoginAt: expect.any(Date),
+          lastActiveAt: expect.any(Date),
+        },
+        $inc: {
+          loginCount: 1,
+        },
+      }
+    );
     await expect(response.json()).resolves.toEqual({
       message: 'Login successful',
       token: 'signed-jwt',

--- a/tests/api/auth-register-me.test.ts
+++ b/tests/api/auth-register-me.test.ts
@@ -39,6 +39,7 @@ describe('auth register and profile routes', () => {
     mocks.getUserIdFromRequest.mockReset();
     mocks.getDb.mockReset();
     mocks.checkRateLimit.mockReset();
+    process.env.ADMIN_EMAILS = '';
     mocks.checkRateLimit.mockResolvedValue(null);
     mocks.hash.mockResolvedValue('hashed-password');
     mocks.generateToken.mockReturnValue('signed-token');
@@ -164,5 +165,73 @@ describe('auth register and profile routes', () => {
       firmTitle: 'Updated Firm',
     });
     expect(body.user).not.toHaveProperty('password');
+  });
+
+  it('returns admin status and refreshes stale activity timestamps', async () => {
+    process.env.ADMIN_EMAILS = 'owner@example.com';
+    mocks.getUserIdFromRequest.mockReturnValue(ids.user);
+    const updateOne = vi.fn().mockResolvedValue({ matchedCount: 1 });
+    const findOne = vi.fn().mockResolvedValue({
+      _id: objectIdLike(ids.user),
+      name: 'Shop Owner',
+      email: 'owner@example.com',
+      firmTitle: '',
+      gstNumber: '',
+      firmPhone: '',
+      firmEmail: '',
+      firmAddress: '',
+      lastActiveAt: new Date(Date.now() - 20 * 60 * 1000),
+    });
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne, updateOne })),
+    });
+
+    const { GET } = await import('@/app/api/auth/me/route');
+    const response = await GET(jsonRequest('http://localhost/api/auth/me'));
+
+    expect(response.status).toBe(200);
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: expect.any(Object) },
+      { $set: { lastActiveAt: expect.any(Date) } }
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      user: {
+        id: ids.user,
+        email: 'owner@example.com',
+        isAdmin: true,
+      },
+    });
+  });
+
+  it('does not refresh activity timestamps inside the throttle window', async () => {
+    mocks.getUserIdFromRequest.mockReturnValue(ids.user);
+    const updateOne = vi.fn().mockResolvedValue({ matchedCount: 1 });
+    const findOne = vi.fn().mockResolvedValue({
+      _id: objectIdLike(ids.user),
+      name: 'Shop Owner',
+      email: 'owner@example.com',
+      firmTitle: '',
+      gstNumber: '',
+      firmPhone: '',
+      firmEmail: '',
+      firmAddress: '',
+      lastActiveAt: new Date(Date.now() - 5 * 60 * 1000),
+    });
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne, updateOne })),
+    });
+
+    const { GET } = await import('@/app/api/auth/me/route');
+    const response = await GET(jsonRequest('http://localhost/api/auth/me'));
+
+    expect(response.status).toBe(200);
+    expect(updateOne).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      user: {
+        id: ids.user,
+        email: 'owner@example.com',
+        isAdmin: false,
+      },
+    });
   });
 });

--- a/tests/components/AdminUsageClient.test.tsx
+++ b/tests/components/AdminUsageClient.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import AdminUsageClient from '@/app/admin/usage/AdminUsageClient';
@@ -13,39 +13,72 @@ vi.mock('next/navigation', () => ({
   useRouter: () => mocks.router,
 }));
 
-const usagePayload = {
-  totalUsers: 2,
-  activeLast24Hours: 1,
-  activeLast7Days: 1,
-  activeLast30Days: 1,
-  newUsersLast7Days: 1,
-  inactive30PlusDays: 1,
-  activeRateLast7Days: 50,
-  activeRateLast30Days: 50,
-  stickinessRate: 100,
-  averageLoginCount: 2.5,
-  generatedAt: '2026-07-02T03:45:00.000Z',
-  users: [
-    {
-      id: 'user-1',
-      name: 'Admin User',
-      email: 'admin@example.com',
-      createdAt: '2026-06-01T10:00:00.000Z',
-      lastLoginAt: '2026-07-01T10:00:00.000Z',
-      lastActiveAt: new Date().toISOString(),
-      loginCount: 5,
-    },
-    {
-      id: 'user-2',
-      name: 'Quiet User',
-      email: 'quiet@example.com',
-      createdAt: '2026-05-01T10:00:00.000Z',
-      lastLoginAt: null,
-      lastActiveAt: null,
-      loginCount: 0,
-    },
-  ],
+const adminUser = {
+  id: 'user-1',
+  name: 'Admin User',
+  email: 'admin@example.com',
+  createdAt: '2026-06-01T10:00:00.000Z',
+  lastLoginAt: '2026-07-01T10:00:00.000Z',
+  lastActiveAt: new Date().toISOString(),
+  loginCount: 5,
 };
+
+const quietUser = {
+  id: 'user-2',
+  name: 'Quiet User',
+  email: 'quiet@example.com',
+  createdAt: '2026-05-01T10:00:00.000Z',
+  lastLoginAt: null,
+  lastActiveAt: null,
+  loginCount: 0,
+};
+
+const pageTwoUser = {
+  id: 'user-3',
+  name: 'Page Two User',
+  email: 'page-two@example.com',
+  createdAt: '2026-04-01T10:00:00.000Z',
+  lastLoginAt: null,
+  lastActiveAt: null,
+  loginCount: 1,
+};
+
+function buildUsagePayload(
+  users = [adminUser, quietUser],
+  pagination = {
+    total: 12,
+    totalUsers: 12,
+    page: 1,
+    pageSize: 10,
+    totalPages: 2,
+    hasNextPage: true,
+    hasPreviousPage: false,
+  }
+) {
+  return {
+    totalUsers: 2,
+    activeLast24Hours: 1,
+    activeLast7Days: 1,
+    activeLast30Days: 1,
+    newUsersLast7Days: 1,
+    inactive30PlusDays: 1,
+    activeRateLast7Days: 50,
+    activeRateLast30Days: 50,
+    stickinessRate: 100,
+    averageLoginCount: 2.5,
+    generatedAt: '2026-07-02T03:45:00.000Z',
+    pagination,
+    users,
+  };
+}
+
+function okJson(payload: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  };
+}
 
 describe('AdminUsageClient', () => {
   beforeEach(() => {
@@ -58,32 +91,103 @@ describe('AdminUsageClient', () => {
 
   it('renders metrics and filters the user table', async () => {
     const user = userEvent.setup();
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: async () => usagePayload,
-      })
-    );
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url, 'http://localhost');
+      const page = parsed.searchParams.get('page');
+      const status = parsed.searchParams.get('status');
+      const search = parsed.searchParams.get('search');
+
+      if (search === 'missing') {
+        return okJson(
+          buildUsagePayload([], {
+            total: 0,
+            totalUsers: 12,
+            page: 1,
+            pageSize: 10,
+            totalPages: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          })
+        );
+      }
+
+      if (status === 'inactive') {
+        return okJson(
+          buildUsagePayload([quietUser], {
+            total: 1,
+            totalUsers: 12,
+            page: 1,
+            pageSize: 10,
+            totalPages: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          })
+        );
+      }
+
+      if (page === '2') {
+        return okJson(
+          buildUsagePayload([pageTwoUser], {
+            total: 12,
+            totalUsers: 12,
+            page: 2,
+            pageSize: 10,
+            totalPages: 2,
+            hasNextPage: false,
+            hasPreviousPage: true,
+          })
+        );
+      }
+
+      return okJson(buildUsagePayload());
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     render(<AdminUsageClient />);
 
     expect(await screen.findByText('User Activity Dashboard')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/usage?page=1&limit=10&status=all',
+      expect.objectContaining({ cache: 'no-store' })
+    );
     expect(screen.getByText('Active Last 24 Hours')).toBeInTheDocument();
     expect(screen.getByText('New Users Last 7 Days')).toBeInTheDocument();
+    expect(screen.getByText('1-10 of 12 users shown')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument();
     expect(screen.getAllByText('Admin User').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Quiet User').length).toBeGreaterThan(0);
 
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    expect((await screen.findAllByText('Page Two User')).length).toBeGreaterThan(0);
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/usage?page=2&limit=10&status=all',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+
     await user.click(screen.getByRole('button', { name: 'Inactive' }));
 
-    expect(screen.queryByText('Admin User')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Admin User')).not.toBeInTheDocument();
+      expect(screen.queryByText('Page Two User')).not.toBeInTheDocument();
+    });
     expect(screen.getAllByText('Quiet User').length).toBeGreaterThan(0);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/admin/usage?page=1&limit=10&status=inactive',
+      expect.objectContaining({ cache: 'no-store' })
+    );
 
     fireEvent.change(screen.getByPlaceholderText('Search users'), {
       target: { value: 'missing' },
     });
 
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/admin/usage?page=1&limit=10&status=inactive&search=missing',
+        expect.objectContaining({ cache: 'no-store' })
+      );
+    });
     expect(
       (await screen.findAllByText('No users match the current search or filter.')).length
     ).toBeGreaterThan(0);

--- a/tests/components/AdminUsageClient.test.tsx
+++ b/tests/components/AdminUsageClient.test.tsx
@@ -72,19 +72,21 @@ describe('AdminUsageClient', () => {
     expect(await screen.findByText('User Activity Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Active Last 24 Hours')).toBeInTheDocument();
     expect(screen.getByText('New Users Last 7 Days')).toBeInTheDocument();
-    expect(screen.getByText('Admin User')).toBeInTheDocument();
-    expect(screen.getByText('Quiet User')).toBeInTheDocument();
+    expect(screen.getAllByText('Admin User').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Quiet User').length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole('button', { name: 'Inactive' }));
 
     expect(screen.queryByText('Admin User')).not.toBeInTheDocument();
-    expect(screen.getByText('Quiet User')).toBeInTheDocument();
+    expect(screen.getAllByText('Quiet User').length).toBeGreaterThan(0);
 
     fireEvent.change(screen.getByPlaceholderText('Search users'), {
       target: { value: 'missing' },
     });
 
-    expect(await screen.findByText('No users match the current search or filter.')).toBeInTheDocument();
+    expect(
+      (await screen.findAllByText('No users match the current search or filter.')).length
+    ).toBeGreaterThan(0);
   });
 
   it('shows an access denied state for non-admin users', async () => {

--- a/tests/components/AdminUsageClient.test.tsx
+++ b/tests/components/AdminUsageClient.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AdminUsageClient from '@/app/admin/usage/AdminUsageClient';
+
+const mocks = vi.hoisted(() => ({
+  router: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => mocks.router,
+}));
+
+const usagePayload = {
+  totalUsers: 2,
+  activeLast24Hours: 1,
+  activeLast7Days: 1,
+  activeLast30Days: 1,
+  newUsersLast7Days: 1,
+  inactive30PlusDays: 1,
+  activeRateLast7Days: 50,
+  activeRateLast30Days: 50,
+  stickinessRate: 100,
+  averageLoginCount: 2.5,
+  generatedAt: '2026-07-02T03:45:00.000Z',
+  users: [
+    {
+      id: 'user-1',
+      name: 'Admin User',
+      email: 'admin@example.com',
+      createdAt: '2026-06-01T10:00:00.000Z',
+      lastLoginAt: '2026-07-01T10:00:00.000Z',
+      lastActiveAt: new Date().toISOString(),
+      loginCount: 5,
+    },
+    {
+      id: 'user-2',
+      name: 'Quiet User',
+      email: 'quiet@example.com',
+      createdAt: '2026-05-01T10:00:00.000Z',
+      lastLoginAt: null,
+      lastActiveAt: null,
+      loginCount: 0,
+    },
+  ],
+};
+
+describe('AdminUsageClient', () => {
+  beforeEach(() => {
+    mocks.router.push.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders metrics and filters the user table', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => usagePayload,
+      })
+    );
+
+    render(<AdminUsageClient />);
+
+    expect(await screen.findByText('User Activity Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Active Last 24 Hours')).toBeInTheDocument();
+    expect(screen.getByText('New Users Last 7 Days')).toBeInTheDocument();
+    expect(screen.getByText('Admin User')).toBeInTheDocument();
+    expect(screen.getByText('Quiet User')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Inactive' }));
+
+    expect(screen.queryByText('Admin User')).not.toBeInTheDocument();
+    expect(screen.getByText('Quiet User')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search users'), {
+      target: { value: 'missing' },
+    });
+
+    expect(await screen.findByText('No users match the current search or filter.')).toBeInTheDocument();
+  });
+
+  it('shows an access denied state for non-admin users', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: 'Forbidden' }),
+      })
+    );
+
+    render(<AdminUsageClient />);
+
+    expect(await screen.findByText('Admin access required')).toBeInTheDocument();
+    expect(mocks.router.push).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add an admin-only user activity dashboard for issue #108.
- Track login count, last login, and last active timestamps for users.
- Expose usage metrics plus paginated, searchable, status-filtered user rows through the admin API.
- Make the registered users table responsive with a mobile card view and desktop pagination controls.

Closes #108

## Validation
- pnpm test
- pnpm exec tsc --noEmit
- pnpm build