### PR TITLE
Fix read-after-write cache consistency across the app

### DIFF
--- a/app/api/bootstrap/route.ts
+++ b/app/api/bootstrap/route.ts
@@ -3,7 +3,7 @@ import { ObjectId } from 'mongodb';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import { isAdminEmail } from '@/lib/admin';
-import { getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 import { ensureUserReadModels, type EntityBalance } from '@/lib/read-models';
 
 const LAST_ACTIVE_WRITE_INTERVAL_MS = 15 * 60 * 1000;
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const cacheKey = await versionedCacheKey('bootstrap', userId);
+    const cacheKey = await requestCacheKey(request, 'bootstrap', userId);
     const cached = await getCachedJson<Record<string, unknown>>(cacheKey);
     if (cached) {
       return NextResponse.json(cached);
@@ -103,4 +103,3 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
-

--- a/app/api/collection-types/route.ts
+++ b/app/api/collection-types/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
-import { bumpCacheVersions, getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { bumpCacheVersions, getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 
 const collectionTypeSchema = z.object({
   name: z.string().min(1, 'Name is required').max(50, 'Name must be 50 characters or less'),
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const cacheKey = await versionedCacheKey('collectionTypes', userId);
+    const cacheKey = await requestCacheKey(request, 'collectionTypes', userId);
     const cached = await getCachedJson<{ collectionTypes: unknown[] }>(cacheKey);
     if (cached) {
       return NextResponse.json(cached);

--- a/app/api/custom-entities/route.ts
+++ b/app/api/custom-entities/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
-import { bumpCacheVersions, getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { bumpCacheVersions, getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 import { entitySearchTokens } from '@/lib/search-normalization';
 import { ensureUserReadModels, refreshUserReadModels, type EntityBalance } from '@/lib/read-models';
 
@@ -40,7 +40,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const cacheKey = await versionedCacheKey('customEntities', userId, collectionType);
+    const cacheKey = await requestCacheKey(request, 'customEntities', userId, collectionType);
     const cached = await getCachedJson<{ entities: unknown[] }>(cacheKey);
     if (cached) {
       return NextResponse.json(cached);

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/lib/mongodb";
 import { getUserIdFromRequest } from "@/lib/auth";
 import { z } from "zod";
-import { bumpCacheVersions, getCachedJson, setCachedJson, versionedCacheKey } from "@/lib/cache-version";
+import { bumpCacheVersions, getCachedJson, requestCacheKey, setCachedJson } from "@/lib/cache-version";
 import { entitySearchTokens } from "@/lib/search-normalization";
 import { ensureUserReadModels, refreshUserReadModels, type EntityBalance } from "@/lib/read-models";
 
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     
-    const cacheKey = await versionedCacheKey('customers', userId);
+    const cacheKey = await requestCacheKey(request, 'customers', userId);
     const cachedCustomers = await getCachedJson<{ customers: unknown[] }>(cacheKey);
     if (cachedCustomers) {
       return NextResponse.json(cachedCustomers, { status: 200 });

--- a/app/api/daily-cash-records/route.ts
+++ b/app/api/daily-cash-records/route.ts
@@ -4,7 +4,7 @@ import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 import { format } from 'date-fns';
-import { bumpCacheVersions, getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { bumpCacheVersions, getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 
 const BILL_URL_MAX_LENGTH = 2048;
 const ALLOWED_BILL_URL_SCHEMES = ['https:'];
@@ -92,7 +92,7 @@ export async function GET(request: NextRequest) {
       const normalizedDate = normalizeDate(parsedDate);
       const dateKey = format(normalizedDate, 'dd-MM-yyyy');
 
-      const cacheKey = await versionedCacheKey('dailyCash', userId, `date:${dateKey}`);
+      const cacheKey = await requestCacheKey(request, 'dailyCash', userId, `date:${dateKey}`);
       const cached = await getCachedJson<Record<string, unknown>>(cacheKey);
       if (cached) {
         return NextResponse.json(cached);
@@ -138,7 +138,7 @@ export async function GET(request: NextRequest) {
       const recordsPerPage = 7;
       const skip = (page - 1) * recordsPerPage;
 
-      const cacheKey = await versionedCacheKey('dailyCash', userId, `page:${page}`);
+      const cacheKey = await requestCacheKey(request, 'dailyCash', userId, `page:${page}`);
       const cached = await getCachedJson<Record<string, unknown>>(cacheKey);
       if (cached) {
         return NextResponse.json(cached);

--- a/app/api/dashboard/stats/route.ts
+++ b/app/api/dashboard/stats/route.ts
@@ -5,7 +5,7 @@ import { subDays, format } from 'date-fns';
 import type { RecentActivity, Transaction } from '@/lib/types';
 import { ObjectId } from 'mongodb';
 import { ensureUserReadModels, type EntityBalance } from '@/lib/read-models';
-import { getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 
 const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 const DATE_REGEX = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
 
     const hasDateFilter = rangeStart !== null && rangeEnd !== null;
     const cacheSuffix = hasDateFilter ? monthParam || `${fromParam}-${toParam}` : 'current';
-    const cacheKey = await versionedCacheKey('dashboard', userId, cacheSuffix);
+    const cacheKey = await requestCacheKey(request, 'dashboard', userId, cacheSuffix);
     const cached = await getCachedJson<Record<string, unknown>>(cacheKey);
     if (cached) {
       return NextResponse.json(cached);

--- a/app/api/inventory/[id]/route.ts
+++ b/app/api/inventory/[id]/route.ts
@@ -3,12 +3,11 @@ import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import type { InventoryItem } from '@/lib/types';
 import { ObjectId } from 'mongodb';
-import redis, { cacheGet } from '@/lib/redis';
 import {
   INVENTORY_ITEM_TTL_SECONDS,
-  inventoryItemKey,
   invalidateInventoryCache,
 } from '@/lib/cache';
+import { getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 import { z } from 'zod';
 import { uppercaseInventoryPayload } from '@/lib/inventory-text';
 import { normalizeIdentifier } from '@/lib/search-normalization';
@@ -114,17 +113,10 @@ export async function GET(
       return NextResponse.json({ error: 'Invalid inventory item id' }, { status: 400 });
     }
 
-    const cacheKey = inventoryItemKey(userId, id);
-    const cached = await cacheGet(cacheKey);
+    const cacheKey = await requestCacheKey(request, 'inventory', userId, `item:${id}`);
+    const cached = await getCachedJson<ReturnType<typeof serializeInventoryItem>>(cacheKey);
     if (cached) {
-      try {
-        return NextResponse.json({ item: JSON.parse(cached) });
-      } catch (parseError) {
-        console.warn('inventory item cache parse failed, falling back to DB:', parseError);
-        redis.del(cacheKey).catch((err) =>
-          console.warn('inventory item stale cache delete failed:', err)
-        );
-      }
+      return NextResponse.json({ item: cached });
     }
 
     const db = await getDb();
@@ -139,9 +131,7 @@ export async function GET(
       item as unknown as InventoryItem & { _id: { toString(): string } }
     );
 
-    redis
-      .setex(cacheKey, INVENTORY_ITEM_TTL_SECONDS, JSON.stringify(serialized))
-      .catch((err) => console.warn('inventory item cache write failed:', err));
+    await setCachedJson(cacheKey, INVENTORY_ITEM_TTL_SECONDS, serialized);
 
     return NextResponse.json({ item: serialized });
   } catch (error) {

--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -13,7 +13,7 @@ import {
 import { z } from 'zod';
 import { uppercaseInventoryPayload } from '@/lib/inventory-text';
 import { scoreInventoryItem } from '@/lib/voice-assistant';
-import { getCacheVersion } from '@/lib/cache-version';
+import { getRequestCacheVersion } from '@/lib/cache-version';
 import { queryTokens, normalizeIdentifier } from '@/lib/search-normalization';
 import { ensureUserReadModels, inventoryDerivedFields, refreshUserReadModels } from '@/lib/read-models';
 
@@ -135,18 +135,28 @@ export async function GET(request: NextRequest) {
     const page = Math.max(parseInt(searchParams.get('page') || '1', 10), 1);
     const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '20', 10), 1), 100);
     const skip = (page - 1) * limit;
-    const cacheVersion = await getCacheVersion('inventory', userId);
+    const cacheVersion = await getRequestCacheVersion(request, 'inventory', userId);
+    const cacheEnabled = cacheVersion !== null;
+    const listCacheKey = cacheEnabled
+      ? inventoryListKey(userId, { page, limit, status, search, version: cacheVersion })
+      : null;
+    const summaryCacheKey = cacheEnabled
+      ? inventorySummaryKey(userId, cacheVersion)
+      : null;
 
-    const listCacheKey = inventoryListKey(userId, { page, limit, status, search, version: cacheVersion });
-    const summaryCacheKey = inventorySummaryKey(userId, cacheVersion);
+    const [cachedList, cachedSummary] = cacheEnabled
+      ? await Promise.all([
+          cacheGet(listCacheKey!),
+          cacheGet(summaryCacheKey!),
+        ])
+      : [null, null];
 
-    const [cachedList, cachedSummary] = await Promise.all([
-      cacheGet(listCacheKey),
-      cacheGet(summaryCacheKey),
-    ]);
-
-    let listPayload = safeParseCache<ListCachePayload>(cachedList, listCacheKey);
-    let summaryPayload = safeParseCache<SummaryCachePayload>(cachedSummary, summaryCacheKey);
+    let listPayload = listCacheKey
+      ? safeParseCache<ListCachePayload>(cachedList, listCacheKey)
+      : null;
+    let summaryPayload = summaryCacheKey
+      ? safeParseCache<SummaryCachePayload>(cachedSummary, summaryCacheKey)
+      : null;
 
     if (!listPayload || !summaryPayload) {
       const db = await getDb();
@@ -245,18 +255,22 @@ export async function GET(request: NextRequest) {
         summaryPayload ?? buildSummaryPayload(),
       ]);
 
-      if (!listPayload) {
+      if (!listPayload && listCacheKey) {
         listPayload = resolvedList;
         redis
           .setex(listCacheKey, INVENTORY_LIST_TTL_SECONDS, JSON.stringify(listPayload))
           .catch((err) => console.warn('inventory list cache write failed:', err));
+      } else if (!listPayload) {
+        listPayload = resolvedList;
       }
 
-      if (!summaryPayload) {
+      if (!summaryPayload && summaryCacheKey) {
         summaryPayload = resolvedSummary;
         redis
           .setex(summaryCacheKey, INVENTORY_SUMMARY_TTL_SECONDS, JSON.stringify(summaryPayload))
           .catch((err) => console.warn('inventory summary cache write failed:', err));
+      } else if (!summaryPayload) {
+        summaryPayload = resolvedSummary;
       }
     }
 

--- a/app/api/invoices/route.ts
+++ b/app/api/invoices/route.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { ClientSession, Db, MongoServerError, ObjectId } from 'mongodb';
 import redis from '@/lib/redis';
 import { invalidateInventoryCache } from '@/lib/cache';
-import { bumpCacheVersions, getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { bumpCacheVersions, getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 import { entitySearchTokens, invoiceSearchTokens, queryTokens } from '@/lib/search-normalization';
 import { refreshUserReadModels } from '@/lib/read-models';
 import {
@@ -155,7 +155,8 @@ export async function GET(request: NextRequest) {
     const limit = Number.isNaN(limitParam) || limitParam < 1 ? 20 : Math.min(limitParam, 100);
     const skip = (page - 1) * limit;
 
-    const cacheKey = await versionedCacheKey(
+    const cacheKey = await requestCacheKey(
+      request,
       'invoices',
       userId,
       `${customerId || ''}:${status || ''}:${search || ''}:${page}:${limit}`

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import { checkRateLimit, rateLimitConfigs } from '@/lib/rateLimit';
-import { getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 import { queryTokens } from '@/lib/search-normalization';
 
 interface SearchResult {
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ results: [] }, { status: 200 });
     }
 
-    const cacheKey = await versionedCacheKey('search', userId, query.toLowerCase());
+    const cacheKey = await requestCacheKey(request, 'search', userId, query.toLowerCase());
     const cached = await getCachedJson<{ results: SearchResult[] }>(cacheKey);
     if (cached) {
       return NextResponse.json(cached, { status: 200 });

--- a/app/api/suppliers/route.ts
+++ b/app/api/suppliers/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import { z } from 'zod';
-import { bumpCacheVersions, getCachedJson, setCachedJson, versionedCacheKey } from '@/lib/cache-version';
+import { bumpCacheVersions, getCachedJson, requestCacheKey, setCachedJson } from '@/lib/cache-version';
 import { entitySearchTokens } from '@/lib/search-normalization';
 import { ensureUserReadModels, refreshUserReadModels, type EntityBalance } from '@/lib/read-models';
 
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const cacheKey = await versionedCacheKey('suppliers', userId);
+    const cacheKey = await requestCacheKey(request, 'suppliers', userId);
     const cached = await getCachedJson<{ suppliers: unknown[] }>(cacheKey);
     if (cached) {
       return NextResponse.json(cached);

--- a/lib/cache-consistency.ts
+++ b/lib/cache-consistency.ts
@@ -1,0 +1,12 @@
+export const CACHE_WRITE_BARRIER_COOKIE = 'easyrakh_cache_write';
+export const CACHE_WRITE_BARRIER_SECONDS = 15;
+
+type CookieReader = {
+  cookies: {
+    get(name: string): { value: string } | undefined;
+  };
+};
+
+export function hasRecentWriteBarrier(request: CookieReader): boolean {
+  return request.cookies.get(CACHE_WRITE_BARRIER_COOKIE)?.value === '1';
+}

--- a/lib/cache-version.ts
+++ b/lib/cache-version.ts
@@ -1,4 +1,8 @@
 import redis from './redis';
+import { hasRecentWriteBarrier } from './cache-consistency';
+
+const CACHE_VERSION_TIMEOUT_MS = 250;
+const CACHE_VALUE_TIMEOUT_MS = 250;
 
 export type CacheNamespace =
   | 'bootstrap'
@@ -15,33 +19,86 @@ export type CacheNamespace =
 export const cacheVersionKey = (namespace: CacheNamespace, userId: string) =>
   `cache:v:${namespace}:${userId}`;
 
-async function redisGetWithTimeout(key: string, timeoutMs: number) {
-  if (typeof redis.get !== 'function') return null;
+type RedisReadResult =
+  | { status: 'available'; value: string | null }
+  | { status: 'unavailable' };
 
+async function redisGetWithTimeout(
+  key: string,
+  timeoutMs: number
+): Promise<RedisReadResult> {
+  if (typeof redis.get !== 'function') return { status: 'unavailable' };
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    return await Promise.race<string | null>([
-      redis.get(key),
-      new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs)),
+    return await Promise.race<RedisReadResult>([
+      redis.get(key).then((value) => ({ status: 'available', value })),
+      new Promise<RedisReadResult>((resolve) => {
+        timeout = setTimeout(() => resolve({ status: 'unavailable' }), timeoutMs);
+      }),
     ]);
   } catch (error) {
     console.warn(`Cache read failed for ${key}`, error);
-    return null;
+    return { status: 'unavailable' };
+  } finally {
+    if (timeout) clearTimeout(timeout);
   }
 }
 
-export async function getCacheVersion(namespace: CacheNamespace, userId: string) {
-  const value = await redisGetWithTimeout(cacheVersionKey(namespace, userId), 100);
-  return value && /^\d+$/.test(value) ? value : '0';
+/**
+ * Returns null when Redis cannot authoritatively provide a cache generation.
+ * Callers must bypass the cache in that case. Falling back to generation "0"
+ * on a timeout can resurrect an old payload after a successful write.
+ */
+export async function getCacheVersion(
+  namespace: CacheNamespace,
+  userId: string
+): Promise<string | null> {
+  const result = await redisGetWithTimeout(
+    cacheVersionKey(namespace, userId),
+    CACHE_VERSION_TIMEOUT_MS
+  );
+
+  if (result.status === 'unavailable') return null;
+  if (result.value === null) return '0';
+
+  if (!/^\d+$/.test(result.value)) {
+    console.warn(`Invalid cache version for ${namespace}:${userId}; bypassing cache`);
+    return null;
+  }
+
+  return result.value;
 }
 
 export async function versionedCacheKey(
   namespace: CacheNamespace,
   userId: string,
   suffix = ''
-) {
+): Promise<string | null> {
   const version = await getCacheVersion(namespace, userId);
+  if (version === null) return null;
+
   const normalizedSuffix = suffix ? `:${suffix}` : '';
   return `${namespace}:${userId}:v${version}${normalizedSuffix}`;
+}
+
+export async function requestCacheKey(
+  request: Parameters<typeof hasRecentWriteBarrier>[0],
+  namespace: CacheNamespace,
+  userId: string,
+  suffix = ''
+): Promise<string | null> {
+  if (hasRecentWriteBarrier(request)) return null;
+  return versionedCacheKey(namespace, userId, suffix);
+}
+
+export async function getRequestCacheVersion(
+  request: Parameters<typeof hasRecentWriteBarrier>[0],
+  namespace: CacheNamespace,
+  userId: string
+): Promise<string | null> {
+  if (hasRecentWriteBarrier(request)) return null;
+  return getCacheVersion(namespace, userId);
 }
 
 export async function bumpCacheVersion(namespace: CacheNamespace, userId: string) {
@@ -59,12 +116,14 @@ export async function bumpCacheVersions(userId: string, namespaces: CacheNamespa
   await Promise.all(uniqueNamespaces.map((namespace) => bumpCacheVersion(namespace, userId)));
 }
 
-export async function getCachedJson<T>(key: string): Promise<T | null> {
-  const cached = await redisGetWithTimeout(key, 250);
-  if (!cached) return null;
+export async function getCachedJson<T>(key: string | null): Promise<T | null> {
+  if (key === null) return null;
+
+  const result = await redisGetWithTimeout(key, CACHE_VALUE_TIMEOUT_MS);
+  if (result.status === 'unavailable' || !result.value) return null;
 
   try {
-    return JSON.parse(cached) as T;
+    return JSON.parse(result.value) as T;
   } catch (error) {
     console.warn(`Cache parse failed for ${key}`, error);
     redis.del(key).catch((err) => console.warn(`Stale cache delete failed for ${key}`, err));
@@ -72,7 +131,9 @@ export async function getCachedJson<T>(key: string): Promise<T | null> {
   }
 }
 
-export function setCachedJson(key: string, ttlSeconds: number, value: unknown) {
+export function setCachedJson(key: string | null, ttlSeconds: number, value: unknown) {
+  if (key === null) return Promise.resolve();
+
   return redis
     .setex(key, ttlSeconds, JSON.stringify(value))
     .catch((error) => console.warn(`Cache write failed for ${key}`, error));

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,10 +1,32 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import {
+  CACHE_WRITE_BARRIER_COOKIE,
+  CACHE_WRITE_BARRIER_SECONDS,
+} from '@/lib/cache-consistency';
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const token = request.cookies.get('token')?.value;
   const { pathname } = request.nextUrl;
   const shouldShowLanding = request.nextUrl.searchParams.get('view') === 'landing';
+
+  if (pathname.startsWith('/api/')) {
+    const response = NextResponse.next();
+    const method = request.method.toUpperCase();
+    const isWrite = !['GET', 'HEAD', 'OPTIONS'].includes(method);
+
+    if (isWrite) {
+      response.cookies.set(CACHE_WRITE_BARRIER_COOKIE, '1', {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/api',
+        maxAge: CACHE_WRITE_BARRIER_SECONDS,
+      });
+    }
+
+    return response;
+  }
 
   if (pathname === '/forgot-password' || pathname.startsWith('/forgot-password/')) {
     return NextResponse.next();
@@ -33,9 +55,10 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    '/api/:path*',
     /*
      * Match all request paths except for the ones starting with:
-     * - api (API routes)
+     * - api (handled by the explicit API matcher above)
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico, sitemap.xml, robots.txt

--- a/tests/api/customers.test.ts
+++ b/tests/api/customers.test.ts
@@ -58,11 +58,13 @@ describe('/api/customers', () => {
 
   it('serves cached customers without hitting MongoDB', async () => {
     mocks.getUserIdFromRequest.mockReturnValue('user-1');
-    mocks.redisGet.mockResolvedValue(
+    mocks.redisGet
+      .mockResolvedValueOnce('4')
+      .mockResolvedValueOnce(
       JSON.stringify({
         customers: [{ id: 'customer-1', name: 'Raj Traders', totalBalance: 2500 }],
       })
-    );
+      );
 
     const { GET } = await import('@/app/api/customers/route');
     const response = await GET(createRequest());
@@ -72,6 +74,63 @@ describe('/api/customers', () => {
       customers: [{ id: 'customer-1', name: 'Raj Traders', totalBalance: 2500 }],
     });
     expect(mocks.getDb).not.toHaveBeenCalled();
+  });
+
+  it('reads MongoDB instead of stale Redis during the post-write barrier', async () => {
+    mocks.getUserIdFromRequest.mockReturnValue('user-1');
+    mocks.redisGet.mockResolvedValue(
+      JSON.stringify({
+        customers: [{ id: 'customer-1', name: 'Stale Name', totalBalance: 2500 }],
+      })
+    );
+
+    const customerCursor = {
+      sort: vi.fn(() => ({
+        toArray: vi.fn().mockResolvedValue([
+          {
+            _id: { toString: () => 'customer-1' },
+            name: 'Fresh Name',
+            openingBalance: 2500,
+            balanceType: 'debit',
+            createdAt: new Date('2026-07-09T00:00:00.000Z'),
+          },
+        ]),
+      })),
+    };
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn((name: string) => {
+        if (name === 'userSummaries') {
+          return { findOne: vi.fn().mockResolvedValue({ userId: 'user-1' }) };
+        }
+        if (name === 'customers') {
+          return { find: vi.fn(() => customerCursor) };
+        }
+        if (name === 'entityBalances') {
+          return {
+            find: vi.fn(() => ({
+              toArray: vi.fn().mockResolvedValue([
+                { entityId: 'customer-1', totalBalance: 2500 },
+              ]),
+            })),
+          };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      }),
+    });
+
+    const { GET } = await import('@/app/api/customers/route');
+    const response = await GET(
+      new NextRequest('http://localhost/api/customers', {
+        headers: { cookie: 'easyrakh_cache_write=1' },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      customers: [{ id: 'customer-1', name: 'Fresh Name', totalBalance: 2500 }],
+    });
+    expect(mocks.redisGet).not.toHaveBeenCalled();
+    expect(mocks.redisSetex).not.toHaveBeenCalled();
   });
 
   it('validates customer creation input', async () => {

--- a/tests/api/dashboard-stats.test.ts
+++ b/tests/api/dashboard-stats.test.ts
@@ -66,7 +66,9 @@ describe('/api/dashboard/stats', () => {
       stats: { totalCredit: 1000, totalDebit: 600, netBalance: -400 },
       periodLabel: 'June 2026',
     };
-    mocks.redisGet.mockResolvedValue(JSON.stringify(cached));
+    mocks.redisGet
+      .mockResolvedValueOnce('0')
+      .mockResolvedValueOnce(JSON.stringify(cached));
 
     const { GET } = await import('@/app/api/dashboard/stats/route');
     const response = await GET(jsonRequest('http://localhost/api/dashboard/stats?month=2026-06'));

--- a/tests/api/inventory-id.test.ts
+++ b/tests/api/inventory-id.test.ts
@@ -4,10 +4,9 @@ import { ids, jsonRequest, objectIdLike, routeParams } from '@/tests/helpers/api
 const mocks = vi.hoisted(() => ({
   getDb: vi.fn(),
   getUserIdFromRequest: vi.fn(),
-  cacheGet: vi.fn(),
+  redisGet: vi.fn(),
   redisSetex: vi.fn(),
   redisDel: vi.fn(),
-  inventoryItemKey: vi.fn(),
   invalidateInventoryCache: vi.fn(),
   cloudinaryAssetsFromFields: vi.fn(),
   deleteCloudinaryAssets: vi.fn(),
@@ -23,15 +22,14 @@ vi.mock('@/lib/mongodb', () => ({
 
 vi.mock('@/lib/redis', () => ({
   default: {
+    get: mocks.redisGet,
     setex: mocks.redisSetex,
     del: mocks.redisDel,
   },
-  cacheGet: mocks.cacheGet,
 }));
 
 vi.mock('@/lib/cache', () => ({
   INVENTORY_ITEM_TTL_SECONDS: 120,
-  inventoryItemKey: mocks.inventoryItemKey,
   invalidateInventoryCache: mocks.invalidateInventoryCache,
 }));
 
@@ -66,19 +64,19 @@ describe('/api/inventory/[id]', () => {
   beforeEach(() => {
     mocks.getDb.mockReset();
     mocks.getUserIdFromRequest.mockReset();
-    mocks.cacheGet.mockReset();
+    mocks.redisGet.mockReset();
     mocks.redisSetex.mockReset();
     mocks.redisDel.mockReset();
-    mocks.inventoryItemKey.mockReset();
     mocks.invalidateInventoryCache.mockReset();
     mocks.cloudinaryAssetsFromFields.mockReset();
     mocks.deleteCloudinaryAssets.mockReset();
 
     mocks.getUserIdFromRequest.mockReturnValue(ids.user);
-    mocks.cacheGet.mockResolvedValue(null);
+    mocks.redisGet
+      .mockResolvedValueOnce('0')
+      .mockResolvedValueOnce(null);
     mocks.redisSetex.mockResolvedValue('OK');
     mocks.redisDel.mockResolvedValue(1);
-    mocks.inventoryItemKey.mockReturnValue('inventory:item:key');
     mocks.invalidateInventoryCache.mockResolvedValue(undefined);
     mocks.cloudinaryAssetsFromFields.mockImplementation(({ publicIds }) =>
       (publicIds || []).filter(Boolean).map((publicId: string) => ({ publicId }))
@@ -95,13 +93,16 @@ describe('/api/inventory/[id]', () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: 'Invalid inventory item id' });
-    expect(mocks.cacheGet).not.toHaveBeenCalled();
+    expect(mocks.redisGet).not.toHaveBeenCalled();
     expect(mocks.getDb).not.toHaveBeenCalled();
   });
 
   it('deletes corrupt item cache entries and falls back to MongoDB', async () => {
     const findOne = vi.fn().mockResolvedValue(storedItem);
-    mocks.cacheGet.mockResolvedValue('{not json');
+    mocks.redisGet
+      .mockReset()
+      .mockResolvedValueOnce('0')
+      .mockResolvedValueOnce('{not json');
     mocks.getDb.mockResolvedValue({
       collection: vi.fn(() => ({ findOne })),
     });
@@ -114,10 +115,12 @@ describe('/api/inventory/[id]', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mocks.redisDel).toHaveBeenCalledWith('inventory:item:key');
+    expect(mocks.redisDel).toHaveBeenCalledWith(
+      `inventory:${ids.user}:v0:item:${ids.inventory}`
+    );
     expect(findOne).toHaveBeenCalledWith({ _id: expect.any(Object), userId: ids.user });
     expect(mocks.redisSetex).toHaveBeenCalledWith(
-      'inventory:item:key',
+      `inventory:${ids.user}:v0:item:${ids.inventory}`,
       120,
       expect.stringContaining('"itemName":"BRAKE PAD"')
     );

--- a/tests/api/inventory.test.ts
+++ b/tests/api/inventory.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getDb: vi.fn(),
   getUserIdFromRequest: vi.fn(),
   cacheGet: vi.fn(),
+  redisGet: vi.fn(),
   redisSetex: vi.fn(),
   redisDel: vi.fn(),
   inventoryListKey: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock('@/lib/mongodb', () => ({
 
 vi.mock('@/lib/redis', () => ({
   default: {
+    get: mocks.redisGet,
     setex: mocks.redisSetex,
     del: mocks.redisDel,
   },
@@ -67,6 +69,7 @@ describe('/api/inventory', () => {
     mocks.getDb.mockReset();
     mocks.getUserIdFromRequest.mockReset();
     mocks.cacheGet.mockReset();
+    mocks.redisGet.mockReset();
     mocks.redisSetex.mockReset();
     mocks.redisDel.mockReset();
     mocks.inventoryListKey.mockReset();
@@ -77,6 +80,7 @@ describe('/api/inventory', () => {
 
     mocks.getUserIdFromRequest.mockReturnValue(ids.user);
     mocks.cacheGet.mockResolvedValue(null);
+    mocks.redisGet.mockResolvedValue('0');
     mocks.redisSetex.mockResolvedValue('OK');
     mocks.redisDel.mockResolvedValue(1);
     mocks.inventoryListKey.mockReturnValue('inventory:list:key');

--- a/tests/api/search.test.ts
+++ b/tests/api/search.test.ts
@@ -83,7 +83,9 @@ describe('/api/search', () => {
     const cached = {
       results: [{ id: ids.customer, name: 'Raj Traders', type: 'customer', href: `/ledger/customer/${ids.customer}` }],
     };
-    mocks.redisGet.mockResolvedValue(JSON.stringify(cached));
+    mocks.redisGet
+      .mockResolvedValueOnce('0')
+      .mockResolvedValueOnce(JSON.stringify(cached));
 
     const { GET } = await import('@/app/api/search/route');
     const response = await GET(jsonRequest('http://localhost/api/search?q=RAJ'));

--- a/tests/unit/cache-version.test.ts
+++ b/tests/unit/cache-version.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  setex: vi.fn(),
+  del: vi.fn(),
+  incr: vi.fn(),
+}));
+
+vi.mock('@/lib/redis', () => ({
+  default: mocks,
+}));
+
+describe('versioned cache safety', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.get.mockReset();
+    mocks.setex.mockReset();
+    mocks.del.mockReset();
+    mocks.incr.mockReset();
+  });
+
+  it('uses version zero only for an authoritative Redis miss', async () => {
+    mocks.get.mockResolvedValue(null);
+    const { versionedCacheKey } = await import('@/lib/cache-version');
+
+    await expect(versionedCacheKey('customers', 'user-1')).resolves.toBe(
+      'customers:user-1:v0'
+    );
+  });
+
+  it('uses the authoritative Redis version', async () => {
+    mocks.get.mockResolvedValue('17');
+    const { versionedCacheKey } = await import('@/lib/cache-version');
+
+    await expect(versionedCacheKey('customers', 'user-1')).resolves.toBe(
+      'customers:user-1:v17'
+    );
+  });
+
+  it('bypasses cache reads and writes when the version lookup times out', async () => {
+    vi.useFakeTimers();
+    mocks.get.mockImplementation(() => new Promise(() => {}));
+    const { getCachedJson, setCachedJson, versionedCacheKey } = await import(
+      '@/lib/cache-version'
+    );
+
+    const cacheKeyPromise = versionedCacheKey('customers', 'user-1');
+    await vi.advanceTimersByTimeAsync(250);
+    const cacheKey = await cacheKeyPromise;
+
+    expect(cacheKey).toBeNull();
+    await expect(getCachedJson(cacheKey)).resolves.toBeNull();
+    await expect(setCachedJson(cacheKey, 600, { customers: [] })).resolves.toBeUndefined();
+    expect(mocks.get).toHaveBeenCalledTimes(1);
+    expect(mocks.setex).not.toHaveBeenCalled();
+  });
+
+  it('bypasses the cache when Redis returns an invalid generation', async () => {
+    mocks.get.mockResolvedValue('not-a-version');
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { versionedCacheKey } = await import('@/lib/cache-version');
+
+    await expect(versionedCacheKey('customers', 'user-1')).resolves.toBeNull();
+    warning.mockRestore();
+  });
+
+  it('bypasses the cache when the version read fails', async () => {
+    mocks.get.mockRejectedValue(new Error('Redis unavailable'));
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { versionedCacheKey } = await import('@/lib/cache-version');
+
+    await expect(versionedCacheKey('customers', 'user-1')).resolves.toBeNull();
+    warning.mockRestore();
+  });
+
+  it('bypasses Redis during the post-write consistency window', async () => {
+    mocks.get.mockResolvedValue('12');
+    const { requestCacheKey } = await import('@/lib/cache-version');
+    const request = {
+      cookies: {
+        get: vi.fn().mockReturnValue({ value: '1' }),
+      },
+    };
+
+    await expect(requestCacheKey(request, 'customers', 'user-1')).resolves.toBeNull();
+    expect(mocks.get).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/middleware-cache-consistency.test.ts
+++ b/tests/unit/middleware-cache-consistency.test.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+import { proxy } from '@/proxy';
+import {
+  CACHE_WRITE_BARRIER_COOKIE,
+  CACHE_WRITE_BARRIER_SECONDS,
+} from '@/lib/cache-consistency';
+
+describe('API cache consistency middleware', () => {
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])(
+    'sets a short read-after-write barrier for %s requests',
+    (method) => {
+      const response = proxy(
+        new NextRequest('http://localhost/api/customers/customer-1', { method })
+      );
+      const barrier = response.cookies.get(CACHE_WRITE_BARRIER_COOKIE);
+
+      expect(barrier?.value).toBe('1');
+      expect(barrier?.httpOnly).toBe(true);
+      expect(barrier?.path).toBe('/api');
+      expect(barrier?.maxAge).toBe(CACHE_WRITE_BARRIER_SECONDS);
+    }
+  );
+
+  it('does not set a write barrier for API reads', () => {
+    const response = proxy(
+      new NextRequest('http://localhost/api/customers', { method: 'GET' })
+    );
+
+    expect(response.cookies.get(CACHE_WRITE_BARRIER_COOKIE)).toBeUndefined();
+  });
+});

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { describe, expect, it } from 'vitest';
-import { middleware } from '@/middleware';
+import { proxy } from '@/proxy';
 
 const createRequest = (path: string, token?: string) => {
   const headers = token ? { cookie: `token=${token}` } : undefined;
@@ -9,28 +9,28 @@ const createRequest = (path: string, token?: string) => {
 
 describe('middleware auth redirects', () => {
   it('sends logged-in visits to the site root directly to the dashboard', () => {
-    const response = middleware(createRequest('/', 'signed-jwt'));
+    const response = proxy(createRequest('/', 'signed-jwt'));
 
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe('http://localhost/dashboard');
   });
 
   it('allows the dashboard logo landing view for logged-in users', () => {
-    const response = middleware(createRequest('/?view=landing', 'signed-jwt'));
+    const response = proxy(createRequest('/?view=landing', 'signed-jwt'));
 
     expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBeNull();
   });
 
   it('keeps the landing page public for logged-out users', () => {
-    const response = middleware(createRequest('/'));
+    const response = proxy(createRequest('/'));
 
     expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBeNull();
   });
 
   it('redirects logged-out users away from protected routes', () => {
-    const response = middleware(createRequest('/dashboard'));
+    const response = proxy(createRequest('/dashboard'));
 
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toBe('http://localhost/login');


### PR DESCRIPTION
## **User description**
## Root cause

Version lookups collapsed Redis timeouts/errors into generation `0`. An old `v0` payload could therefore be served immediately after a successful mutation and overwrite fresh client state. The configured Redis endpoint is a single master, so replica propagation is not involved.

## Fix

- distinguish authoritative cache misses from unavailable/slow/invalid version reads
- bypass Redis and read MongoDB whenever the cache generation is uncertain
- add a 15-second HTTP-only post-write barrier so immediate GETs always read the source of truth
- apply the request-aware cache path to customers, suppliers, custom entities, dashboard, bootstrap, invoices, search, collection types, daily cash, and inventory
- migrate inventory detail caching onto the shared versioned namespace
- migrate Next.js middleware to the supported `proxy.ts` convention

## Verification

- `pnpm test:unit` — 115 passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm build` — passed
- ESLint — no errors
- production-server probe confirmed write responses carry the consistency-barrier cookie


___

## **CodeAnt-AI Description**
**Prevent stale data from reappearing right after writes**

### What Changed
- API reads now skip cache lookups for a short time after a write, so users see fresh data instead of an older cached result
- Cache reads stop falling back to version `0` when Redis is slow, invalid, or unavailable, and those requests now read from the database instead
- Inventory reads now avoid cached list and item data when cache state is uncertain, which also removes the old corrupt-cache fallback path
- The app’s request handler now sets the short write barrier cookie for API write requests, and the middleware file has been moved to the supported `proxy` entry point

### Impact
`✅ Fewer stale lists after saving changes`
`✅ Fewer “old data came back” moments after edits`
`✅ Clearer handling when cache storage is slow or unavailable`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
