### PR TITLE
Fix Redis cold-start connection failures

### DIFF
--- a/lib/cache-version.ts
+++ b/lib/cache-version.ts
@@ -1,7 +1,7 @@
 import redis from './redis';
 import { hasRecentWriteBarrier } from './cache-consistency';
 
-const CACHE_VERSION_TIMEOUT_MS = 250;
+const CACHE_VERSION_TIMEOUT_MS = 500;
 const CACHE_VALUE_TIMEOUT_MS = 250;
 
 export type CacheNamespace =

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -12,7 +12,10 @@ const redis = new Redis(Number(process.env.REDIS_PORT), process.env.REDIS_HOST, 
     return delay;
   },
   enableReadyCheck: true,
-  enableOfflineQueue: false,
+  // lazyConnect starts the connection on the first command. That command must
+  // be allowed to queue until the socket is ready, especially on serverless
+  // cold starts; otherwise ioredis rejects it before connecting.
+  enableOfflineQueue: true,
   connectTimeout: 3000,
   lazyConnect: true,
 });

--- a/tests/unit/cache-version.test.ts
+++ b/tests/unit/cache-version.test.ts
@@ -46,7 +46,7 @@ describe('versioned cache safety', () => {
     );
 
     const cacheKeyPromise = versionedCacheKey('customers', 'user-1');
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(500);
     const cacheKey = await cacheKeyPromise;
 
     expect(cacheKey).toBeNull();

--- a/tests/unit/redis-config.test.ts
+++ b/tests/unit/redis-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const instance = {
+    on: vi.fn(),
+  };
+
+  return {
+    instance,
+    Redis: vi.fn(function RedisMock() {
+      return instance;
+    }),
+  };
+});
+
+vi.mock('ioredis', () => ({
+  default: mocks.Redis,
+}));
+
+describe('Redis client configuration', () => {
+  it('queues the first command while a lazy connection is starting', async () => {
+    await import('@/lib/redis');
+
+    expect(mocks.Redis).toHaveBeenCalledWith(
+      6379,
+      '127.0.0.1',
+      expect.objectContaining({
+        lazyConnect: true,
+        enableOfflineQueue: true,
+        enableReadyCheck: true,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## **User description**
## Production finding

After #121 deployed, the live health endpoint consistently reported Redis as unhealthy with `Stream isn't writeable and enableOfflineQueue options is false`. The client uses `lazyConnect: true`, so rejecting the offline queue causes the first command on every serverless cold instance to fail before the connection can become ready.

## Fix

- allow the first command to queue while lazy connection setup completes
- raise the authoritative version-read deadline from 250 ms to 500 ms to accommodate the measured ~324 ms cold connection while retaining safe DB fallback
- add a regression test for the Redis client configuration

## Verification

- live local Redis first-command probe: `PONG` in 324 ms
- `pnpm test:unit` — 116 passed
- `pnpm exec tsc --noEmit` — passed
- `pnpm build` — passed


___

## **CodeAnt-AI Description**
**Fix Redis cold-start command failures and extend cache version lookup timeout**

### What Changed
- Redis now accepts the first command while a lazy connection is still starting, preventing cold-start failures on serverless instances
- The cache version lookup waits longer before falling back, reducing unnecessary cache bypasses when Redis takes a few hundred milliseconds to respond
- Added a regression test to confirm the Redis client uses a queued first command during startup

### Impact
`✅ Fewer Redis cold-start failures`
`✅ Fewer cache bypasses during startup`
`✅ Clearer serverless health checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
