### PR TITLE
Fix inactive inventory filtering

### DIFF
--- a/app/api/inventory/export-pdf/route.ts
+++ b/app/api/inventory/export-pdf/route.ts
@@ -7,12 +7,9 @@ import autoTable from 'jspdf-autotable';
 import { ObjectId } from 'mongodb';
 import { z } from 'zod';
 import type { InventoryItem } from '@/lib/types';
-import { normalizeIdentifier } from '@/lib/search-normalization';
+import { getInventoryStatusFilter, normalizeIdentifier } from '@/lib/search-normalization';
 import { scoreInventorySearch } from '@/lib/inventory-search';
 
-const LOW_STOCK_THRESHOLD = 5;
-const INACTIVE_THRESHOLD_DAYS = 60;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const STATUS_LABELS: Record<string, string> = {
   all: 'All Items',
   'in-stock': 'In Stock',
@@ -36,20 +33,6 @@ const supplierOrderSchema = z.object({
     .min(1, 'Select at least one inventory item')
     .max(300, 'Supplier orders can include up to 300 items'),
 });
-
-function zeroStockDateCondition(operator: '$gt' | '$lte', cutoff: Date) {
-  const dateCondition = { [operator]: cutoff };
-  const conditions: Record<string, unknown>[] = [
-    { lastQuantityUpdatedAt: dateCondition },
-    { lastQuantityUpdatedAt: null, createdAt: dateCondition },
-  ];
-
-  if (operator === '$lte') {
-    conditions.push({ lastQuantityUpdatedAt: null, createdAt: null });
-  }
-
-  return { $or: conditions };
-}
 
 function escapeRegex(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -96,20 +79,10 @@ export async function GET(request: NextRequest) {
     const db = await getDb();
     const inventoryCollection = db.collection<InventoryItem>('inventory');
 
-    const query: Record<string, unknown> = { userId };
-    const inactiveCutoff = new Date(Date.now() - INACTIVE_THRESHOLD_DAYS * MS_PER_DAY);
-
-    if (status === 'in-stock') {
-      query.quantity = { $gt: LOW_STOCK_THRESHOLD };
-    } else if (status === 'low-stock' || status === 'restock') {
-      query.quantity = { $gt: 0, $lte: LOW_STOCK_THRESHOLD };
-    } else if (status === 'out-of-stock') {
-      query.quantity = { $lte: 0 };
-      query.$and = [zeroStockDateCondition('$gt', inactiveCutoff)];
-    } else if (status === 'inactive') {
-      query.quantity = { $lte: 0 };
-      query.$and = [zeroStockDateCondition('$lte', inactiveCutoff)];
-    }
+    const query: Record<string, unknown> = {
+      userId,
+      ...getInventoryStatusFilter(status),
+    };
 
     if (brand) query.brand = brand;
     if (location) query.location = location;

--- a/app/api/inventory/route.ts
+++ b/app/api/inventory/route.ts
@@ -13,7 +13,7 @@ import {
 import { z } from 'zod';
 import { uppercaseInventoryPayload } from '@/lib/inventory-text';
 import { getRequestCacheVersion } from '@/lib/cache-version';
-import { normalizeIdentifier } from '@/lib/search-normalization';
+import { getInventoryStatusFilter, normalizeIdentifier } from '@/lib/search-normalization';
 import { ensureUserReadModels, inventoryDerivedFields, refreshUserReadModels } from '@/lib/read-models';
 import {
   fuzzyCandidateTokens,
@@ -142,6 +142,7 @@ export async function GET(request: NextRequest) {
     const page = Math.max(parseInt(searchParams.get('page') || '1', 10), 1);
     const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '20', 10), 1), 100);
     const skip = (page - 1) * limit;
+    const statusNow = new Date();
     const cacheVersion = await getRequestCacheVersion(request, 'inventory', userId);
     const cacheEnabled = cacheVersion !== null;
     const listCacheKey = cacheEnabled
@@ -179,17 +180,10 @@ export async function GET(request: NextRequest) {
       const inventoryCollection = db.collection<InventoryItem>('inventory');
 
       const buildListPayload = async (): Promise<ListCachePayload> => {
-        const query: Record<string, unknown> = { userId };
-
-        if (status === 'in-stock') {
-          query.stockStatus = 'in-stock';
-        } else if (status === 'low-stock' || status === 'restock') {
-          query.stockStatus = 'low-stock';
-        } else if (status === 'out-of-stock') {
-          query.stockStatus = 'out-of-stock';
-        } else if (status === 'inactive') {
-          query.stockStatus = 'inactive';
-        }
+        const query: Record<string, unknown> = {
+          userId,
+          ...getInventoryStatusFilter(status, statusNow),
+        };
 
         if (brand) query.brand = brand;
         if (location) query.location = location;
@@ -272,13 +266,26 @@ export async function GET(request: NextRequest) {
       };
 
       const buildSummaryPayload = async (): Promise<SummaryCachePayload> => {
-        const [summary, lowStockItems] = await Promise.all([
+        const lowStockQuery = {
+          userId,
+          ...getInventoryStatusFilter('low-stock', statusNow),
+        };
+        const [summary, lowStockItems, restockItems, outOfStockItems, inactiveItems] = await Promise.all([
           ensureUserReadModels(db, userId),
           inventoryCollection
-            .find({ userId, stockStatus: 'low-stock' })
+            .find(lowStockQuery)
             .sort({ quantity: 1, updatedAt: -1, createdAt: -1 })
             .limit(20)
             .toArray(),
+          inventoryCollection.countDocuments(lowStockQuery),
+          inventoryCollection.countDocuments({
+            userId,
+            ...getInventoryStatusFilter('out-of-stock', statusNow),
+          }),
+          inventoryCollection.countDocuments({
+            userId,
+            ...getInventoryStatusFilter('inactive', statusNow),
+          }),
         ]);
 
         // Summaries created before supplier facets were introduced do not
@@ -293,7 +300,12 @@ export async function GET(request: NextRequest) {
         }
 
         return {
-          stats: summary.inventory,
+          stats: {
+            ...summary.inventory,
+            restockItems,
+            outOfStockItems,
+            inactiveItems,
+          },
           lowStockItems: lowStockItems.map(serializeInventoryItem),
         };
       };

--- a/lib/search-normalization.ts
+++ b/lib/search-normalization.ts
@@ -69,6 +69,44 @@ export function getInactiveCutoff(now = new Date()) {
   return new Date(now.getTime() - INACTIVE_THRESHOLD_DAYS * MS_PER_DAY);
 }
 
+function zeroStockDateFilter(operator: '$gt' | '$lte', cutoff: Date) {
+  const dateCondition = { [operator]: cutoff };
+  const conditions: Record<string, unknown>[] = [
+    { lastQuantityUpdatedAt: dateCondition },
+    { lastQuantityUpdatedAt: null, createdAt: dateCondition },
+  ];
+
+  // Items with no quantity date or creation date use the Unix epoch in
+  // getInventoryStockStatus, so they belong to the inactive group.
+  if (operator === '$lte') {
+    conditions.push({ lastQuantityUpdatedAt: null, createdAt: null });
+  }
+
+  return { $or: conditions };
+}
+
+export function getInventoryStatusFilter(status: string, now = new Date()): Record<string, unknown> {
+  if (status === 'in-stock') {
+    return { quantity: { $gt: LOW_STOCK_THRESHOLD } };
+  }
+  if (status === 'low-stock' || status === 'restock') {
+    return { quantity: { $gt: 0, $lte: LOW_STOCK_THRESHOLD } };
+  }
+  if (status === 'out-of-stock') {
+    return {
+      quantity: { $lte: 0 },
+      $and: [zeroStockDateFilter('$gt', getInactiveCutoff(now))],
+    };
+  }
+  if (status === 'inactive') {
+    return {
+      quantity: { $lte: 0 },
+      $and: [zeroStockDateFilter('$lte', getInactiveCutoff(now))],
+    };
+  }
+  return {};
+}
+
 export function getInventoryStockStatus(
   item: Pick<InventoryItem, 'quantity' | 'lastQuantityUpdatedAt' | 'createdAt'>,
   now = new Date()
@@ -109,4 +147,3 @@ export function invoiceSearchTokens(invoice: {
 }) {
   return buildSearchTokens(invoice.invoiceNumber, invoice.customerName, invoice.customerPhone);
 }
-

--- a/scripts/check-hot-query-shapes.ts
+++ b/scripts/check-hot-query-shapes.ts
@@ -2,6 +2,7 @@ import { config } from 'dotenv';
 import { MongoClient } from 'mongodb';
 import path from 'node:path';
 import { initializeIndexes } from '../lib/db-indexes';
+import { getInventoryStatusFilter } from '../lib/search-normalization';
 
 config({ path: path.resolve(process.cwd(), '.env.local') });
 config();
@@ -69,7 +70,10 @@ async function main() {
   );
   await assertIndexedQuery(
     'inventory list',
-    db.collection('inventory').find({ userId, stockStatus: 'low-stock' }).sort({ updatedAt: -1, createdAt: -1 }).limit(20)
+    db.collection('inventory')
+      .find({ userId, ...getInventoryStatusFilter('low-stock') })
+      .sort({ updatedAt: -1, createdAt: -1 })
+      .limit(20)
   );
   await assertIndexedQuery(
     'invoice list',

--- a/tests/api/inventory.test.ts
+++ b/tests/api/inventory.test.ts
@@ -140,6 +140,91 @@ describe('/api/inventory', () => {
     });
   });
 
+  it('loads inactive items using their zero-stock age instead of a stored status', async () => {
+    const find = vi.fn(() => {
+      const chain = {
+        sort: vi.fn(),
+        skip: vi.fn(),
+        limit: vi.fn(),
+        toArray: vi.fn().mockResolvedValue([]),
+      };
+      chain.sort.mockReturnValue(chain);
+      chain.skip.mockReturnValue(chain);
+      chain.limit.mockReturnValue(chain);
+      return chain;
+    });
+    const countDocuments = vi.fn((query: Record<string, unknown>) => {
+      const quantity = query.quantity as { $gt?: number } | undefined;
+      const dateFilters = query.$and as
+        | Array<{
+            $or?: Array<{ lastQuantityUpdatedAt?: { $gt?: Date; $lte?: Date } }>;
+          }>
+        | undefined;
+      if (quantity?.$gt === 0) return Promise.resolve(1);
+      const dateOperator = dateFilters?.[0]?.$or?.[0]?.lastQuantityUpdatedAt;
+      if (dateOperator?.$gt) return Promise.resolve(2);
+      if (dateOperator?.$lte) return Promise.resolve(3);
+      return Promise.resolve(0);
+    });
+    const inventoryCollection = {
+      find,
+      countDocuments,
+    };
+    const summary = {
+      userId: ids.user,
+      inventory: {
+        totalItems: 6,
+        totalQuantity: 10,
+        totalValue: 100,
+        outOfStockItems: 0,
+        inactiveItems: 0,
+        restockItems: 0,
+        lowStockThreshold: 5,
+        locations: [],
+        brands: [],
+        suppliers: [],
+      },
+    };
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn((name: string) =>
+        name === 'inventory'
+          ? inventoryCollection
+          : { findOne: vi.fn().mockResolvedValue(summary) }
+      ),
+    });
+
+    const { GET } = await import('@/app/api/inventory/route');
+    const response = await GET(
+      jsonRequest('http://localhost/api/inventory?status=inactive&page=1&limit=16')
+    );
+
+    expect(response.status).toBe(200);
+    expect(find).toHaveBeenCalledWith({
+      userId: ids.user,
+      quantity: { $lte: 0 },
+      $and: [
+        {
+          $or: [
+            { lastQuantityUpdatedAt: { $lte: expect.any(Date) } },
+            {
+              lastQuantityUpdatedAt: null,
+              createdAt: { $lte: expect.any(Date) },
+            },
+            { lastQuantityUpdatedAt: null, createdAt: null },
+          ],
+        },
+      ],
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      stats: {
+        restockItems: 1,
+        outOfStockItems: 2,
+        inactiveItems: 3,
+      },
+      pagination: { total: 3 },
+    });
+  });
+
   it('returns a duplicate item-number conflict with the existing item details', async () => {
     const findOne = vi.fn().mockResolvedValue({
       _id: objectIdLike(ids.otherInventory),

--- a/tests/unit/search-normalization.test.ts
+++ b/tests/unit/search-normalization.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getInventoryStatusFilter,
+  getInventoryStockStatus,
+} from '@/lib/search-normalization';
+
+describe('inventory stock status', () => {
+  const now = new Date('2026-07-21T12:00:00.000Z');
+  const inactiveCutoff = new Date('2026-05-22T12:00:00.000Z');
+
+  it('classifies a zero-stock item as inactive once it reaches 60 days', () => {
+    expect(
+      getInventoryStockStatus(
+        {
+          quantity: 0,
+          lastQuantityUpdatedAt: inactiveCutoff,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        now
+      )
+    ).toBe('inactive');
+  });
+
+  it('builds the inactive database filter from quantity age instead of stored status', () => {
+    expect(getInventoryStatusFilter('inactive', now)).toEqual({
+      quantity: { $lte: 0 },
+      $and: [
+        {
+          $or: [
+            { lastQuantityUpdatedAt: { $lte: inactiveCutoff } },
+            {
+              lastQuantityUpdatedAt: null,
+              createdAt: { $lte: inactiveCutoff },
+            },
+            { lastQuantityUpdatedAt: null, createdAt: null },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('keeps recently depleted items in out of stock', () => {
+    expect(getInventoryStatusFilter('out-of-stock', now)).toEqual({
+      quantity: { $lte: 0 },
+      $and: [
+        {
+          $or: [
+            { lastQuantityUpdatedAt: { $gt: inactiveCutoff } },
+            {
+              lastQuantityUpdatedAt: null,
+              createdAt: { $gt: inactiveCutoff },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
## What changed

- Derive inventory status filters from quantity and the 60-day zero-stock age at request time.
- Calculate dashboard counts and tab results with the same query conditions.
- Reuse the shared status logic for inventory PDF exports and query-shape checks.
- Add API and unit regression coverage.

## Why

The inventory summary recalculated inactive status from dates, while the inactive tab filtered on a stored `stockStatus`. That stored value could remain `out-of-stock` after an item crossed the 60-day inactivity threshold, causing the count and list to disagree.

## Validation

- `pnpm test:unit` (125 tests passed)
- `pnpm exec tsc --noEmit`
- ESLint completed with no errors (existing warnings remain)


___

## **CodeAnt-AI Description**
**Use zero-stock age for inactive inventory and keep inventory counts aligned**

### What Changed
- Inventory pages and PDF exports now group items by how long they have been out of stock, so inactive items no longer depend on a stored status value.
- The inventory summary now shows matching counts for restock, out of stock, and inactive items using the same rules as the item list.
- Query-shape checks and regression tests were updated to cover the new inventory filtering behavior.

### Impact
`✅ Matching inactive inventory counts and lists`
`✅ Fewer incorrect inactive items`
`✅ Consistent inventory exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
