### PR TITLE
Fix partial invoice payment updates

### DIFF
--- a/app/api/invoices/[id]/route.ts
+++ b/app/api/invoices/[id]/route.ts
@@ -10,6 +10,7 @@ import { invoiceSearchTokens } from '@/lib/search-normalization';
 import { refreshUserReadModels } from '@/lib/read-models';
 import {
   applyInventoryAdjustments,
+  areInvoiceItemsUnchanged,
   getInventoryDiffAdjustments,
   getInventoryRestoreAdjustments,
   InvoiceStockError,
@@ -200,7 +201,10 @@ export async function PUT(
         const previousItems = (existingInvoice.items || []) as InvoiceItem[];
         let nextItems = previousItems;
 
-        if (validatedData.items !== undefined) {
+        if (
+          validatedData.items !== undefined &&
+          !areInvoiceItemsUnchanged(previousItems, validatedData.items)
+        ) {
           nextItems = await normalizeInvoiceItemsForSave(
             db,
             userId,
@@ -220,7 +224,7 @@ export async function PUT(
           adjustedIds.forEach((itemId) => changedInventoryIds.add(itemId));
         }
 
-        let paidAmount = validatedData.paidAmount ?? existingInvoice.paidAmount;
+        const paidAmount = validatedData.paidAmount ?? existingInvoice.paidAmount;
         let status = validatedData.status ?? existingInvoice.status;
 
         if (paidAmount >= totalAmount) {

--- a/lib/invoice-stock.ts
+++ b/lib/invoice-stock.ts
@@ -16,6 +16,25 @@ export type InventoryAdjustment = {
   quantityDelta: number;
 };
 
+export function areInvoiceItemsUnchanged(
+  previousItems: InvoiceItem[],
+  nextItems: InvoiceItemInput[]
+): boolean {
+  if (previousItems.length !== nextItems.length) return false;
+
+  return previousItems.every((previousItem, index) => {
+    const nextItem = nextItems[index];
+
+    return (
+      (previousItem.inventoryItemId || '') === (nextItem.inventoryItemId || '') &&
+      normalizeItemNumber(previousItem.itemNumber) === normalizeItemNumber(nextItem.itemNumber) &&
+      normalizeItemName(previousItem.itemName) === normalizeItemName(nextItem.itemName) &&
+      previousItem.quantity === nextItem.quantity &&
+      previousItem.amount === nextItem.amount
+    );
+  });
+}
+
 export class InvoiceStockError extends Error {
   code: string;
   status: number;

--- a/tests/api/invoices.test.ts
+++ b/tests/api/invoices.test.ts
@@ -429,6 +429,77 @@ describe('/api/invoices stock sync', () => {
     expect(invoices.updateOne).toHaveBeenCalled();
   });
 
+  it('updates payment without revalidating unchanged historical inventory details', async () => {
+    const historicalItem = {
+      ...linkedItem(1, 450),
+      itemNumber: 'OLD-BP-104',
+      itemName: 'OLD BRAKE PAD',
+    };
+    const previousInvoice = {
+      _id: objectIdLike(ids.transaction),
+      invoiceNumber: 'INV-2026-06-0001',
+      customerName: 'Raj Traders',
+      items: [historicalItem],
+      totalAmount: 450,
+      paidAmount: 100,
+      status: 'partial',
+      addedToLedger: false,
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-01T00:00:00.000Z'),
+    };
+    const updatedInvoice = {
+      ...previousInvoice,
+      paidAmount: 250,
+      status: 'partial',
+      updatedAt: new Date('2026-06-02T00:00:00.000Z'),
+    };
+    const invoices = {
+      findOne: vi.fn().mockResolvedValueOnce(previousInvoice).mockResolvedValueOnce(updatedInvoice),
+      updateOne: vi.fn().mockResolvedValue({ matchedCount: 1 }),
+    };
+    const inventory = {
+      find: vi.fn(),
+      findOne: vi.fn(),
+      findOneAndUpdate: vi.fn(),
+    };
+    mocks.getDb.mockResolvedValue(
+      dbWithCollections({
+        invoices,
+        transactions: {},
+        inventory,
+      })
+    );
+
+    const { PUT } = await import('@/app/api/invoices/[id]/route');
+    const response = await PUT(
+      jsonRequest(
+        `http://localhost/api/invoices/${ids.transaction}`,
+        {
+          items: [historicalItem],
+          paidAmount: 250,
+          status: 'partial',
+        },
+        { method: 'PUT' }
+      ),
+      routeParams({ id: ids.transaction })
+    );
+
+    expect(response.status).toBe(200);
+    expect(inventory.find).not.toHaveBeenCalled();
+    expect(inventory.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(invoices.updateOne).toHaveBeenCalledWith(
+      { _id: expect.any(Object), userId: ids.user },
+      {
+        $set: expect.objectContaining({
+          paidAmount: 250,
+          status: 'partial',
+        }),
+      },
+      { session: mocks.session }
+    );
+    expect(invoices.updateOne.mock.calls[0][1].$set).not.toHaveProperty('items');
+  });
+
   it('blocks an edit that increases quantity beyond available stock', async () => {
     const previousInvoice = {
       _id: objectIdLike('507f1f77bcf86cd799439099'),


### PR DESCRIPTION
## **User description**
## What changed

- Detect when invoice items submitted by the edit screen are unchanged.
- Skip inventory item normalization and stock adjustments for payment-only invoice updates.
- Add a regression test for invoices containing historical part details that no longer match the current inventory record.

## Why

The invoice edit screen resends every line item even when only the paid amount changes. The API was revalidating those historical lines against current inventory data, which could incorrectly return `INVENTORY_ITEM_MISMATCH` and block the payment update.

## Impact

Payment and notes updates now succeed without touching inventory when invoice items are unchanged. Genuine item or quantity edits continue through the existing inventory validation and stock-difference logic.

## Validation

- `pnpm exec vitest run tests/api/invoices.test.ts`
- `pnpm exec tsc --noEmit`
- ESLint on the changed files
- `git diff --check`


___

## **CodeAnt-AI Description**
**Skip inventory checks when an invoice payment is updated without changing items**

### What Changed
- Payment-only invoice edits now save without rechecking inventory when the line items are unchanged.
- Historical item details can stay on the invoice even if they no longer match the current inventory record.
- Item changes still go through inventory validation and stock updates as before.
- Added a regression test for updating paid amount on an invoice with old item details.

### Impact
`✅ Fewer payment updates blocked by old inventory data`
`✅ Faster partial invoice edits`
`✅ Clearer handling of payment-only invoice changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
