### PR TITLE
Support invoice items without part numbers

### DIFF
--- a/app/api/inventory/suggestions/route.ts
+++ b/app/api/inventory/suggestions/route.ts
@@ -2,7 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/mongodb';
 import { getUserIdFromRequest } from '@/lib/auth';
 import type { InventoryItem } from '@/lib/types';
-import { normalizeIdentifier } from '@/lib/search-normalization';
+import {
+  normalizeIdentifier,
+  queryTokens,
+} from '@/lib/search-normalization';
+import {
+  fuzzyCandidateTokens,
+  scoreInventorySearch,
+} from '@/lib/inventory-search';
 
 function escapeRegex(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -16,25 +23,46 @@ export async function GET(request: NextRequest) {
     }
 
     const searchParams = request.nextUrl.searchParams;
-    const itemNumber = (searchParams.get('itemNumber') || '').trim();
+    // Keep itemNumber as a compatibility alias for older invoice clients.
+    const query = (
+      searchParams.get('query') ||
+      searchParams.get('itemNumber') ||
+      ''
+    ).trim().slice(0, 100);
     const limitParam = Number(searchParams.get('limit') || '8');
     const limit = Number.isFinite(limitParam)
       ? Math.min(Math.max(Math.trunc(limitParam), 1), 10)
       : 8;
 
-    if (!itemNumber) {
+    if (!query) {
       return NextResponse.json({ items: [] });
     }
 
     const db = await getDb();
     const inventoryCollection = db.collection<InventoryItem>('inventory');
-    const regex = { $regex: `^${escapeRegex(normalizeIdentifier(itemNumber))}` };
+    const normalizedQuery = normalizeIdentifier(query);
+    const prefixRegex = { $regex: `^${escapeRegex(normalizedQuery)}` };
+    const exactSearchTokens = queryTokens(query);
+    const fuzzyTokens = fuzzyCandidateTokens(query);
+    const searchClauses: Record<string, unknown>[] = [
+      { itemNumberKey: prefixRegex },
+      { itemName: prefixRegex },
+      { uniqueCode: prefixRegex },
+      { brand: prefixRegex },
+      { location: prefixRegex },
+    ];
+    if (exactSearchTokens.length > 0) {
+      searchClauses.push({ searchTokens: { $all: exactSearchTokens } });
+    }
+    if (fuzzyTokens.length > 0) {
+      searchClauses.push({ fuzzySearchTokens: { $in: fuzzyTokens } });
+    }
 
-    const items = await inventoryCollection
+    const candidates = await inventoryCollection
       .find(
         {
           userId,
-          itemNumberKey: regex,
+          $or: searchClauses,
         },
         {
           projection: {
@@ -44,12 +72,31 @@ export async function GET(request: NextRequest) {
             quantity: 1,
             unitOfMeasure: 1,
             buyingPrice: 1,
+            uniqueCode: 1,
+            brand: 1,
+            location: 1,
+            updatedAt: 1,
           },
         }
       )
-      .sort({ itemNumber: 1, updatedAt: -1 })
-      .limit(limit)
+      .sort({ updatedAt: -1 })
+      .limit(100)
       .toArray();
+
+    const items = candidates
+      .map((item, index) => ({
+        item,
+        index,
+        score: scoreInventorySearch(item, query),
+      }))
+      .filter(({ score }) => score >= 0.42)
+      .sort((left, right) =>
+        right.score - left.score ||
+        Number(right.item.quantity || 0) - Number(left.item.quantity || 0) ||
+        left.index - right.index
+      )
+      .slice(0, limit)
+      .map(({ item }) => item);
 
     return NextResponse.json({
       items: items.map((item) => ({
@@ -59,6 +106,9 @@ export async function GET(request: NextRequest) {
         quantity: item.quantity || 0,
         unitOfMeasure: item.unitOfMeasure || '',
         buyingPrice: item.buyingPrice ?? null,
+        uniqueCode: item.uniqueCode || '',
+        brand: item.brand || '',
+        location: item.location || '',
       })),
     });
   } catch (error) {

--- a/components/InvoiceItemsEditor.tsx
+++ b/components/InvoiceItemsEditor.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import toast from 'react-hot-toast';
-import { CheckCircle2, Plus, Trash2 } from 'lucide-react';
+import { CheckCircle2, Plus, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
@@ -28,9 +28,13 @@ interface InventorySuggestion {
   quantity: number;
   unitOfMeasure: string;
   buyingPrice: number | null;
+  uniqueCode: string;
+  brand: string;
+  location: string;
 }
 
 type ItemField = 'itemNumber' | 'itemName' | 'quantity' | 'amount' | 'unitCost';
+type InventorySearchField = 'itemNumber' | 'itemName';
 
 interface InvoiceItemsEditorProps {
   items: EditableInvoiceItem[];
@@ -79,8 +83,9 @@ export default function InvoiceItemsEditor({
   const [pendingFocus, setPendingFocus] = useState<{ itemId: string; field: ItemField } | null>(
     null
   );
-  const [activePartInput, setActivePartInput] = useState<{
+  const [activeInventorySearch, setActiveInventorySearch] = useState<{
     itemId: string;
+    field: InventorySearchField;
     query: string;
   } | null>(null);
   const [suggestions, setSuggestions] = useState<InventorySuggestion[]>([]);
@@ -150,7 +155,7 @@ export default function InvoiceItemsEditor({
   );
 
   const closeSuggestions = useCallback(() => {
-    setActivePartInput(null);
+    setActiveInventorySearch(null);
     setSuggestions([]);
     setHighlightedIndex(0);
     setLoadingSuggestions(false);
@@ -158,12 +163,14 @@ export default function InvoiceItemsEditor({
   }, []);
 
   const updateSuggestionMenuPosition = useCallback(() => {
-    if (!activePartInput) {
+    if (!activeInventorySearch) {
       setSuggestionMenuPosition(null);
       return;
     }
 
-    const node = inputRefs.current[activePartInput.itemId]?.itemNumber;
+    const node = inputRefs.current[activeInventorySearch.itemId]?.[
+      activeInventorySearch.field
+    ];
     if (!node) {
       setSuggestionMenuPosition(null);
       return;
@@ -175,11 +182,11 @@ export default function InvoiceItemsEditor({
       left: rect.left,
       width: rect.width,
     });
-  }, [activePartInput]);
+  }, [activeInventorySearch]);
 
   useEffect(() => {
-    const query = activePartInput?.query.trim();
-    if (!activePartInput || !query) {
+    const query = activeInventorySearch?.query.trim();
+    if (!activeInventorySearch || !query) {
       setSuggestions([]);
       setLoadingSuggestions(false);
       return;
@@ -189,7 +196,7 @@ export default function InvoiceItemsEditor({
     const timer = window.setTimeout(async () => {
       setLoadingSuggestions(true);
       try {
-        const params = new URLSearchParams({ itemNumber: query, limit: '8' });
+        const params = new URLSearchParams({ query, limit: '8' });
         const response = await fetch(`/api/inventory/suggestions?${params.toString()}`, {
           cache: 'no-store',
           signal: controller.signal,
@@ -214,7 +221,7 @@ export default function InvoiceItemsEditor({
       controller.abort();
       window.clearTimeout(timer);
     };
-  }, [activePartInput, suggestionDelayMs]);
+  }, [activeInventorySearch, suggestionDelayMs]);
 
   useEffect(() => {
     const onPointerDown = (event: MouseEvent | TouchEvent) => {
@@ -236,7 +243,7 @@ export default function InvoiceItemsEditor({
   }, [closeSuggestions]);
 
   useEffect(() => {
-    if (!activePartInput) return;
+    if (!activeInventorySearch) return;
 
     updateSuggestionMenuPosition();
     window.addEventListener('resize', updateSuggestionMenuPosition);
@@ -245,7 +252,7 @@ export default function InvoiceItemsEditor({
       window.removeEventListener('resize', updateSuggestionMenuPosition);
       window.removeEventListener('scroll', updateSuggestionMenuPosition, true);
     };
-  }, [activePartInput, updateSuggestionMenuPosition]);
+  }, [activeInventorySearch, updateSuggestionMenuPosition]);
 
   const selectSuggestion = useCallback(
     (itemId: string, suggestion: InventorySuggestion) => {
@@ -288,8 +295,31 @@ export default function InvoiceItemsEditor({
       inventoryItemId: undefined,
       ...(item.inventoryItemId ? { itemName: '', unitCost: undefined, unitCostInput: '' } : {}),
     });
-    setActivePartInput({ itemId: item.id, query: value });
+    setActiveInventorySearch({ itemId: item.id, field: 'itemNumber', query: value });
     window.requestAnimationFrame(updateSuggestionMenuPosition);
+  };
+
+  const handleItemNameChange = (item: EditableInvoiceItem, value: string) => {
+    // The inventory ID remains the stock link. A typed name is only the
+    // description printed on this invoice unless another suggestion is chosen.
+    updateItem(item.id, { itemName: value });
+    if (item.inventoryItemId) {
+      closeSuggestions();
+      return;
+    }
+    setActiveInventorySearch({ itemId: item.id, field: 'itemName', query: value });
+    window.requestAnimationFrame(updateSuggestionMenuPosition);
+  };
+
+  const unlinkInventoryItem = (item: EditableInvoiceItem) => {
+    updateItem(item.id, {
+      inventoryItemId: undefined,
+      itemNumber: '',
+      unitCost: undefined,
+      unitCostInput: '',
+    });
+    closeSuggestions();
+    setPendingFocus({ itemId: item.id, field: 'itemName' });
   };
 
   const handleKeyDown = (
@@ -297,9 +327,12 @@ export default function InvoiceItemsEditor({
     field: ItemField,
     event: KeyboardEvent<HTMLInputElement>
   ) => {
-    const suggestionsOpen = activePartInput?.itemId === itemId && suggestions.length > 0;
+    const suggestionsOpen =
+      activeInventorySearch?.itemId === itemId &&
+      activeInventorySearch.field === field &&
+      suggestions.length > 0;
 
-    if (field === 'itemNumber') {
+    if (field === 'itemNumber' || field === 'itemName') {
       if (event.key === 'ArrowDown' && suggestionsOpen) {
         event.preventDefault();
         setHighlightedIndex((index) => Math.min(index + 1, suggestions.length - 1));
@@ -345,7 +378,9 @@ export default function InvoiceItemsEditor({
   };
 
   const activeSuggestionsOpen =
-    activePartInput && suggestionMenuPosition && (suggestions.length > 0 || loadingSuggestions);
+    activeInventorySearch &&
+    suggestionMenuPosition &&
+    (suggestions.length > 0 || loadingSuggestions);
 
   return (
     <div ref={rootRef} className="rounded-lg border border-gray-200 bg-white">
@@ -376,7 +411,11 @@ export default function InvoiceItemsEditor({
                       value={item.itemNumber}
                       onChange={(event) => handleItemNumberChange(item, event.target.value)}
                       onFocus={() =>
-                        setActivePartInput({ itemId: item.id, query: item.itemNumber })
+                        setActiveInventorySearch({
+                          itemId: item.id,
+                          field: 'itemNumber',
+                          query: item.itemNumber,
+                        })
                       }
                       onKeyDown={(event) => handleKeyDown(item.id, 'itemNumber', event)}
                       placeholder="Part number"
@@ -390,18 +429,35 @@ export default function InvoiceItemsEditor({
                       <Input
                         ref={(node) => setInputRef(item.id, 'itemName', node)}
                         value={item.itemName}
-                        onChange={(event) =>
-                          updateItem(item.id, { itemName: event.target.value })
-                        }
+                        onChange={(event) => handleItemNameChange(item, event.target.value)}
+                        onFocus={() => {
+                          if (!item.inventoryItemId) {
+                            setActiveInventorySearch({
+                              itemId: item.id,
+                              field: 'itemName',
+                              query: item.itemName,
+                            });
+                          }
+                        }}
                         onKeyDown={(event) => handleKeyDown(item.id, 'itemName', event)}
                         placeholder="Item name"
                         aria-label={`Row ${index + 1} item name`}
+                        autoComplete="off"
                         className={`h-9 bg-white shadow-none ${
                           item.inventoryItemId ? 'pr-9' : ''
                         }`}
                       />
                       {item.inventoryItemId && (
-                        <CheckCircle2 className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-green-600" />
+                        <button
+                          type="button"
+                          onClick={() => unlinkInventoryItem(item)}
+                          className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-0.5 rounded px-1 py-0.5 text-green-600 hover:bg-green-50 hover:text-red-600"
+                          aria-label={`Unlink row ${index + 1} inventory item`}
+                          title="Linked to inventory. Click to choose a different item."
+                        >
+                          <CheckCircle2 className="h-4 w-4" />
+                          <X className="h-3 w-3" />
+                        </button>
                       )}
                     </div>
                   </td>
@@ -520,7 +576,7 @@ export default function InvoiceItemsEditor({
                   role="option"
                   aria-selected={suggestionIndex === highlightedIndex}
                   onMouseDown={(event) => event.preventDefault()}
-                  onClick={() => selectSuggestion(activePartInput.itemId, suggestion)}
+                  onClick={() => selectSuggestion(activeInventorySearch.itemId, suggestion)}
                   className={`w-full px-3 py-2.5 text-left text-sm ${
                     suggestionIndex === highlightedIndex
                       ? 'bg-blue-50 text-blue-900'
@@ -530,11 +586,18 @@ export default function InvoiceItemsEditor({
                   <span className="flex items-center justify-between gap-3">
                     <span className="min-w-0">
                       <span className="block truncate font-semibold">
-                        {suggestion.itemNumber}
+                        {suggestion.itemNumber || 'No part number'}
                       </span>
                       <span className="block truncate text-xs text-gray-500">
                         {suggestion.itemName}
                       </span>
+                      {(suggestion.brand || suggestion.location || suggestion.uniqueCode) && (
+                        <span className="block truncate text-[11px] text-gray-400">
+                          {[suggestion.brand, suggestion.location, suggestion.uniqueCode]
+                            .filter(Boolean)
+                            .join(' • ')}
+                        </span>
+                      )}
                     </span>
                     <span className="shrink-0 rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
                       {suggestion.quantity} {suggestion.unitOfMeasure}

--- a/lib/invoice-stock.ts
+++ b/lib/invoice-stock.ts
@@ -285,7 +285,9 @@ export async function normalizeInvoiceItemsForSave(
       normalizedItems.push(buildCostedItem({
         inventoryItemId: inventoryItem._id.toString(),
         itemNumber: storedItemNumber,
-        itemName: inventoryItem.itemName,
+        // The inventory ID controls stock and cost. The entered name is an
+        // invoice-only description and must not rename the inventory record.
+        itemName,
       }, normalizedUnitCost, typeof storedCost === 'number' ? 'inventory_snapshot' : 'entered'));
       continue;
     }
@@ -315,7 +317,7 @@ export async function normalizeInvoiceItemsForSave(
         normalizedItems.push(buildCostedItem({
           inventoryItemId: inventoryItem._id.toString(),
           itemNumber: inventoryItem.itemNumber || itemNumber,
-          itemName: inventoryItem.itemName,
+          itemName,
         }, normalizedUnitCost, typeof storedCost === 'number' ? 'inventory_snapshot' : 'entered'));
         continue;
       }

--- a/tests/api/inventory-suggestions.test.ts
+++ b/tests/api/inventory-suggestions.test.ts
@@ -40,7 +40,7 @@ describe('/api/inventory/suggestions', () => {
     expect(mocks.getDb).not.toHaveBeenCalled();
   });
 
-  it('returns an empty list for blank item-number queries without querying MongoDB', async () => {
+  it('returns an empty list for a blank search without querying MongoDB', async () => {
     const { GET } = await import('@/app/api/inventory/suggestions/route');
     const response = await GET(jsonRequest('http://localhost/api/inventory/suggestions?itemNumber='));
 
@@ -49,7 +49,7 @@ describe('/api/inventory/suggestions', () => {
     expect(mocks.getDb).not.toHaveBeenCalled();
   });
 
-  it('searches user-scoped inventory item numbers and returns the invoice suggestion shape', async () => {
+  it('searches user-scoped inventory details and returns the invoice suggestion shape', async () => {
     const chain = findChain([
       {
         _id: objectIdLike(ids.inventory),
@@ -58,6 +58,9 @@ describe('/api/inventory/suggestions', () => {
         quantity: 8,
         unitOfMeasure: 'PCS',
         buyingPrice: 450,
+        uniqueCode: 'UC-104',
+        brand: 'BOSCH',
+        location: 'RACK A',
       },
     ]);
     mocks.getDb.mockResolvedValue({
@@ -69,10 +72,14 @@ describe('/api/inventory/suggestions', () => {
 
     expect(response.status).toBe(200);
     expect(chain.find).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         userId: ids.user,
-        itemNumberKey: { $regex: '^BP' },
-      },
+        $or: expect.arrayContaining([
+          { itemNumberKey: { $regex: '^BP' } },
+          { itemName: { $regex: '^BP' } },
+          { searchTokens: { $all: ['bp'] } },
+        ]),
+      }),
       {
         projection: {
           _id: 1,
@@ -81,10 +88,14 @@ describe('/api/inventory/suggestions', () => {
           quantity: 1,
           unitOfMeasure: 1,
           buyingPrice: 1,
+          uniqueCode: 1,
+          brand: 1,
+          location: 1,
+          updatedAt: 1,
         },
       }
     );
-    expect(chain.limit).toHaveBeenCalledWith(10);
+    expect(chain.limit).toHaveBeenCalledWith(100);
     await expect(response.json()).resolves.toEqual({
       items: [
         {
@@ -94,8 +105,60 @@ describe('/api/inventory/suggestions', () => {
           quantity: 8,
           unitOfMeasure: 'PCS',
           buyingPrice: 450,
+          uniqueCode: 'UC-104',
+          brand: 'BOSCH',
+          location: 'RACK A',
         },
       ],
+    });
+  });
+
+  it('finds an inventory item by name when its part number is empty', async () => {
+    const chain = findChain([
+      {
+        _id: objectIdLike(ids.inventory),
+        itemNumber: '',
+        itemName: 'BRAKE SHOE',
+        quantity: 6,
+        unitOfMeasure: 'PCS',
+        buyingPrice: 300,
+        uniqueCode: 'SHOE-01',
+        brand: 'BOSCH',
+        location: 'RACK B',
+      },
+    ]);
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ find: chain.find })),
+    });
+
+    const { GET } = await import('@/app/api/inventory/suggestions/route');
+    const response = await GET(
+      jsonRequest('http://localhost/api/inventory/suggestions?query=brake%20shoe')
+    );
+
+    expect(response.status).toBe(200);
+    expect(chain.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: ids.user,
+        $or: expect.arrayContaining([
+          { itemName: { $regex: '^BRAKE SHOE' } },
+          { searchTokens: { $all: ['brake', 'shoe'] } },
+        ]),
+      }),
+      expect.any(Object)
+    );
+    await expect(response.json()).resolves.toEqual({
+      items: [{
+        id: ids.inventory,
+        itemNumber: '',
+        itemName: 'BRAKE SHOE',
+        quantity: 6,
+        unitOfMeasure: 'PCS',
+        buyingPrice: 300,
+        uniqueCode: 'SHOE-01',
+        brand: 'BOSCH',
+        location: 'RACK B',
+      }],
     });
   });
 });

--- a/tests/api/invoices.test.ts
+++ b/tests/api/invoices.test.ts
@@ -213,7 +213,7 @@ describe('/api/invoices stock sync', () => {
           expect.objectContaining({
             inventoryItemId: ids.inventory,
             itemNumber: 'BP-104',
-            itemName: 'BRAKE PAD',
+            itemName: 'typed name',
             quantity: 2,
             amount: 900,
             unitPrice: 450,
@@ -226,6 +226,73 @@ describe('/api/invoices stock sync', () => {
       { session: mocks.session }
     );
     expect(mocks.invalidateInventoryCache).toHaveBeenCalledWith(ids.user, ids.inventory);
+  });
+
+  it('links stock by inventory ID when the item has no part number and preserves the invoice description', async () => {
+    const inventoryItemWithoutNumber = {
+      _id: objectIdLike(ids.inventory),
+      itemNumber: '',
+      itemName: 'BRAKE SHOE',
+      quantity: 8,
+      buyingPrice: 300,
+    };
+    const invoiceFind = invoiceFindChain();
+    const insertOne = vi.fn().mockResolvedValue({
+      insertedId: objectIdLike('507f1f77bcf86cd799439099'),
+    });
+    const inventoryLookup = inventoryFindChain([inventoryItemWithoutNumber]);
+    const inventory = {
+      find: inventoryLookup.find,
+      findOne: vi.fn(),
+      findOneAndUpdate: vi.fn().mockResolvedValue({
+        ...inventoryItemWithoutNumber,
+        quantity: 6,
+      }),
+    };
+    mocks.getDb.mockResolvedValue(dbWithCollections({
+      invoices: { find: invoiceFind.find, insertOne },
+      customers: {},
+      transactions: {},
+      inventory,
+    }));
+
+    const { POST } = await import('@/app/api/invoices/route');
+    const response = await POST(jsonRequest(
+      'http://localhost/api/invoices',
+      createBody([{
+        inventoryItemId: ids.inventory,
+        itemNumber: '',
+        itemName: 'FRONT BRAKE SHOE',
+        quantity: 2,
+        unitPrice: 500,
+      }])
+    ));
+
+    expect(response.status).toBe(201);
+    expect(inventory.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: expect.any(Object), userId: ids.user, quantity: { $gte: 2 } },
+      expect.objectContaining({ $inc: { quantity: -2 } }),
+      { returnDocument: 'after', session: mocks.session }
+    );
+    expect(insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [expect.objectContaining({
+          inventoryItemId: ids.inventory,
+          itemNumber: '',
+          itemName: 'FRONT BRAKE SHOE',
+          quantity: 2,
+          unitPrice: 500,
+          unitCost: 300,
+          amount: 1000,
+          cogs: 600,
+          grossProfit: 400,
+        })],
+        totalAmount: 1000,
+        totalCogs: 600,
+        grossProfit: 400,
+      }),
+      { session: mocks.session }
+    );
   });
 
   it('creates manual invoice rows without touching inventory quantity', async () => {

--- a/tests/components/InvoiceItemsEditor.test.tsx
+++ b/tests/components/InvoiceItemsEditor.test.tsx
@@ -15,6 +15,9 @@ const suggestions = [
     quantity: 8,
     unitOfMeasure: 'PCS',
     buyingPrice: 450,
+    uniqueCode: 'UC-104',
+    brand: 'BOSCH',
+    location: 'RACK A',
   },
   {
     id: '507f1f77bcf86cd799439017',
@@ -23,6 +26,9 @@ const suggestions = [
     quantity: 3,
     unitOfMeasure: 'PCS',
     buyingPrice: 700,
+    uniqueCode: 'UC-205',
+    brand: 'BREMBO',
+    location: 'RACK B',
   },
 ];
 
@@ -93,6 +99,123 @@ describe('InvoiceItemsEditor', () => {
     await user.keyboard('{ArrowDown}{Enter}');
 
     expect(screen.getByLabelText('Row 1 item name')).toHaveValue('BRAKE PAD PREMIUM');
+  });
+
+  it('finds and links an inventory item by name when it has no part number', async () => {
+    const blankNumberSuggestion = {
+      id: '507f1f77bcf86cd799439018',
+      itemNumber: '',
+      itemName: 'BRAKE SHOE',
+      quantity: 6,
+      unitOfMeasure: 'PCS',
+      buyingPrice: 300,
+      uniqueCode: 'SHOE-01',
+      brand: 'BOSCH',
+      location: 'RACK B',
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ items: [blankNumberSuggestion] }),
+      })
+    );
+    const user = userEvent.setup();
+    render(<EditorHarness />);
+
+    await user.type(screen.getByLabelText('Row 1 item name'), 'BRAKE SHOE');
+    await screen.findByText('No part number');
+    expect(screen.getByText('BOSCH • RACK B • SHOE-01')).toBeInTheDocument();
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByLabelText('Row 1 part number')).toHaveValue('');
+    expect(screen.getByLabelText('Row 1 item name')).toHaveValue('BRAKE SHOE');
+    expect(screen.getByLabelText('Row 1 cost price')).toHaveValue(300);
+    expect(screen.getByLabelText('Row 1 quantity')).toHaveFocus();
+    expect(JSON.parse(screen.getByTestId('items-json').textContent || '[]')[0]).toMatchObject({
+      inventoryItemId: blankNumberSuggestion.id,
+      itemNumber: '',
+      itemName: 'BRAKE SHOE',
+      unitCost: 300,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('query=BRAKE+SHOE'),
+      expect.any(Object)
+    );
+  });
+
+  it('keeps the inventory link and part number when only the invoice name is edited', async () => {
+    const user = userEvent.setup();
+    render(<EditorHarness initialItems={[{
+      id: '1',
+      inventoryItemId: suggestions[0].id,
+      itemNumber: suggestions[0].itemNumber,
+      itemName: suggestions[0].itemName,
+      quantity: 1,
+      amount: 500,
+      unitCost: 450,
+      unitCostInput: '450',
+    }]} />);
+
+    const itemName = screen.getByLabelText('Row 1 item name');
+    await user.clear(itemName);
+    await user.type(itemName, 'FRONT BRAKE PAD');
+
+    expect(JSON.parse(screen.getByTestId('items-json').textContent || '[]')[0]).toMatchObject({
+      inventoryItemId: suggestions[0].id,
+      itemNumber: 'BP-104',
+      itemName: 'FRONT BRAKE PAD',
+      unitCost: 450,
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('can explicitly unlink a selected inventory item before choosing another one', async () => {
+    const user = userEvent.setup();
+    render(<EditorHarness initialItems={[{
+      id: '1',
+      inventoryItemId: suggestions[0].id,
+      itemNumber: suggestions[0].itemNumber,
+      itemName: suggestions[0].itemName,
+      quantity: 1,
+      amount: 500,
+      unitCost: 450,
+      unitCostInput: '450',
+    }]} />);
+
+    await user.click(screen.getByLabelText('Unlink row 1 inventory item'));
+
+    const unlinked = JSON.parse(screen.getByTestId('items-json').textContent || '[]')[0];
+    expect(unlinked.inventoryItemId).toBeUndefined();
+    expect(unlinked.itemNumber).toBe('');
+    expect(unlinked.itemName).toBe('BRAKE PAD');
+    expect(unlinked.unitCost).toBeUndefined();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Row 1 item name')).toHaveFocus();
+    });
+  });
+
+  it('clears the inventory link when the part number itself is changed', async () => {
+    const user = userEvent.setup();
+    render(<EditorHarness initialItems={[{
+      id: '1',
+      inventoryItemId: suggestions[0].id,
+      itemNumber: suggestions[0].itemNumber,
+      itemName: suggestions[0].itemName,
+      quantity: 1,
+      amount: 500,
+      unitCost: 450,
+      unitCostInput: '450',
+    }]} />);
+
+    const partNumber = screen.getByLabelText('Row 1 part number');
+    await user.clear(partNumber);
+    await user.type(partNumber, 'NEW-1');
+
+    const edited = JSON.parse(screen.getByTestId('items-json').textContent || '[]')[0];
+    expect(edited.inventoryItemId).toBeUndefined();
+    expect(edited.itemName).toBe('');
+    expect(edited.unitCost).toBeUndefined();
   });
 
   it('moves through inputs with Enter and back with Shift+Enter', async () => {


### PR DESCRIPTION
## **User description**
## What changed

- Allow invoice inventory search by part number, item name, unique code, brand, or location.
- Let inventory items with an empty part number be selected by name and linked by their stable inventory ID.
- Keep edited item names as invoice-only descriptions without changing the linked inventory item or its part number.
- Add an explicit unlink control before choosing a different inventory item.
- Add API and UI regression coverage for missing part numbers and inventory-link behavior.

## Why

The invoice suggestion API previously searched only by part number. Existing inventory items with no part number were therefore invisible in invoice creation and could be entered only as manual rows, which would not deduct their stock.

## Data and safety impact

- Existing inventory and invoice records are not migrated or modified.
- The inventory ID remains authoritative for stock deduction and cost price.
- Editing an invoice description does not rename the inventory item.
- Changing the part number or explicitly unlinking removes the inventory link so a different item can be selected safely.
- Existing transactional stock and insufficient-stock checks remain in place.

## Validation

- TypeScript typecheck passed.
- Lint passed with 0 errors.
- 146 unit/integration tests passed.
- Production build passed.
- 4 Playwright browser tests passed.


___

## **CodeAnt-AI Description**
**Support invoice items without part numbers and keep invoice names separate from inventory names**

### What Changed
- Inventory search now finds items by part number, item name, unique code, brand, or location, including items with no part number.
- Suggestion results show extra item details and allow linking a no-part-number item from its name.
- On invoices, editing the item name now changes only the invoice line description; it no longer renames the linked inventory item.
- Users can unlink a selected inventory item before choosing another one, and changing the part number also clears the existing link.
- Added coverage for no-part-number items, name-based search, unlinking, and preserving stock links during invoice saving.

### Impact
`✅ Invoice items without part numbers can be added to stock-linked invoices`
`✅ Clearer inventory search across names and item details`
`✅ Fewer accidental inventory name changes from invoice edits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
