### PR TITLE
Fix invoice PDF viewing in cash records

### DIFF
--- a/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route.ts
+++ b/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route.ts
@@ -1,0 +1,87 @@
+import { ObjectId } from 'mongodb';
+import { NextRequest, NextResponse } from 'next/server';
+import { getUserIdFromRequest } from '@/lib/auth';
+import { cloudinaryAssetsFromFields } from '@/lib/cloudinary-cleanup';
+import { downloadRawAsset } from '@/lib/cloudinary';
+import { getDb } from '@/lib/mongodb';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+function pdfFilename(publicId: string) {
+  const rawName = publicId.split('/').pop() || 'bill.pdf';
+  const safeName = rawName.replace(/[^a-zA-Z0-9._-]/g, '-');
+  return safeName.toLowerCase().endsWith('.pdf') ? safeName : `${safeName}.pdf`;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; entryId: string }> }
+) {
+  try {
+    const userId = getUserIdFromRequest(request);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id: recordId, entryId } = await params;
+    if (!ObjectId.isValid(recordId) || !ObjectId.isValid(entryId)) {
+      return NextResponse.json({ error: 'Invalid cash record or entry ID' }, { status: 400 });
+    }
+
+    const recordObjectId = new ObjectId(recordId);
+    const entryObjectId = new ObjectId(entryId);
+    const db = await getDb();
+    const record = await db.collection('dailyCashRecords').findOne(
+      {
+        _id: recordObjectId,
+        userId,
+        'entries._id': entryObjectId,
+      },
+      {
+        projection: {
+          entries: { $elemMatch: { _id: entryObjectId } },
+        },
+      }
+    );
+    const entry = record?.entries?.[0];
+
+    if (!entry) {
+      return NextResponse.json({ error: 'Bill attachment not found' }, { status: 404 });
+    }
+
+    const [asset] = cloudinaryAssetsFromFields({
+      publicIds: [entry.billPublicId],
+      urls: [entry.billUrl],
+    });
+    if (
+      !asset ||
+      asset.resourceType !== 'raw' ||
+      !/\.pdf$/i.test(asset.publicId)
+    ) {
+      return NextResponse.json({ error: 'PDF attachment not found' }, { status: 404 });
+    }
+
+    const downloaded = await downloadRawAsset(asset.publicId);
+    if (downloaded.buffer.subarray(0, 5).toString() !== '%PDF-') {
+      throw new Error('Cloudinary returned an invalid PDF');
+    }
+
+    return new NextResponse(new Uint8Array(downloaded.buffer), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Length': String(downloaded.buffer.length),
+        'Content-Disposition': `inline; filename="${pdfFilename(asset.publicId)}"`,
+        'Cache-Control': 'private, no-store, max-age=0',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (error) {
+    console.error('Cash record bill download error:', error);
+    return NextResponse.json(
+      { error: 'Failed to load the bill attachment' },
+      { status: 502 }
+    );
+  }
+}

--- a/app/daily-cash-record/page.tsx
+++ b/app/daily-cash-record/page.tsx
@@ -28,6 +28,10 @@ import { ASSISTANT_DATA_UPDATED_EVENT } from '@/lib/assistant-events';
 import Image from 'next/image';
 import { compressImage, isCompressibleImage, formatFileSize } from '@/lib/imageCompression';
 import { motion } from 'motion/react'
+import {
+  getDailyCashBillViewUrl,
+  isPdfBillAttachment,
+} from '@/lib/bill-attachments';
 
 const MAX_BILL_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
 const ACCEPTED_BILL_TYPES = [
@@ -122,6 +126,7 @@ export default function DailyCashRecordPage() {
   // Bill view modal state
   const [billViewOpen, setBillViewOpen] = useState(false);
   const [billViewUrl, setBillViewUrl] = useState<string>('');
+  const [billViewIsPdf, setBillViewIsPdf] = useState(false);
 
   const resetBillState = () => {
     setBillPreviewUrl('');
@@ -130,6 +135,12 @@ export default function DailyCashRecordPage() {
     setBillUploading(false);
     if (billFileInputRef.current) billFileInputRef.current.value = '';
   };
+
+  const openBillAttachment = useCallback((recordId: string, entry: CashEntry) => {
+    setBillViewUrl(getDailyCashBillViewUrl(recordId, entry));
+    setBillViewIsPdf(isPdfBillAttachment(entry));
+    setBillViewOpen(true);
+  }, []);
 
   const handleBillFileSelect = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -1146,7 +1157,7 @@ export default function DailyCashRecordPage() {
                                 <Button
                                   size="sm"
                                   variant="outline"
-                                  onClick={() => { setBillViewUrl(entry.billUrl!); setBillViewOpen(true); }}
+                                  onClick={() => openBillAttachment(viewingRecord.id, entry)}
                                   aria-label="View bill"
                                   title="View bill"
                                   className="cash-record-icon-button h-7 w-7 rounded-lg border p-0 transition-colors"
@@ -1223,7 +1234,7 @@ export default function DailyCashRecordPage() {
                                   <Button
                                     size="sm"
                                     variant="outline"
-                                    onClick={() => { setBillViewUrl(entry.billUrl!); setBillViewOpen(true); }}
+                                    onClick={() => openBillAttachment(viewingRecord.id, entry)}
                                     className="cash-record-icon-button h-7 w-7 rounded-lg border p-0 transition-colors"
                                     title="View bill"
                                     aria-label="View bill"
@@ -1584,26 +1595,28 @@ export default function DailyCashRecordPage() {
         </Dialog>
 
         {/* Bill View Modal */}
-        <Dialog open={billViewOpen} onOpenChange={setBillViewOpen}>
-          <DialogContent className="sm:max-w-xl">
+        <Dialog
+          open={billViewOpen}
+          onOpenChange={(open) => {
+            setBillViewOpen(open);
+            if (!open) {
+              setBillViewUrl('');
+              setBillViewIsPdf(false);
+            }
+          }}
+        >
+          <DialogContent className="max-w-[95vw] sm:max-w-4xl">
             <DialogHeader>
               <DialogTitle>Bill Attachment</DialogTitle>
             </DialogHeader>
             <div className="space-y-4">
               {billViewUrl ? (
-                billViewUrl.toLowerCase().includes('.pdf') ? (
-                  <div className="rounded border border-dashed p-4 text-sm text-gray-700 text-center">
-                    <FileText className="h-8 w-8 text-red-500 mx-auto mb-2" />
-                    <p>Bill is a PDF document.</p>
-                    <a
-                      href={billViewUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:underline text-sm mt-2 inline-block"
-                    >
-                      Open PDF in new tab
-                    </a>
-                  </div>
+                billViewIsPdf ? (
+                  <iframe
+                    src={billViewUrl}
+                    title="Bill PDF"
+                    className="h-[70vh] w-full rounded-md border bg-white"
+                  />
                 ) : (
                   <Image
                     src={billViewUrl}

--- a/lib/bill-attachments.ts
+++ b/lib/bill-attachments.ts
@@ -1,0 +1,26 @@
+export type BillAttachment = {
+  id: string;
+  billUrl?: string;
+  billPublicId?: string;
+};
+
+export function isPdfBillAttachment(
+  attachment: Pick<BillAttachment, 'billUrl' | 'billPublicId'>
+) {
+  return [attachment.billUrl, attachment.billPublicId].some((value) =>
+    /\.pdf(?:$|[?#])/i.test(value || '')
+  );
+}
+
+export function getDailyCashBillViewUrl(recordId: string, attachment: BillAttachment) {
+  if (!attachment.billUrl) return '';
+  if (!isPdfBillAttachment(attachment)) return attachment.billUrl;
+
+  return [
+    '/api/daily-cash-records',
+    encodeURIComponent(recordId),
+    'entries',
+    encodeURIComponent(attachment.id),
+    'bill',
+  ].join('/');
+}

--- a/lib/cloudinary.ts
+++ b/lib/cloudinary.ts
@@ -40,3 +40,22 @@ export async function uploadBuffer(
 export async function deleteAsset(publicId: string, resourceType: CloudinaryResourceType = 'image') {
   await cloudinary.uploader.destroy(publicId, { resource_type: resourceType });
 }
+
+export async function downloadRawAsset(publicId: string) {
+  const expiresAt = Math.floor(Date.now() / 1000) + 60;
+  const downloadUrl = cloudinary.utils.private_download_url(publicId, '', {
+    resource_type: 'raw',
+    type: 'upload',
+    expires_at: expiresAt,
+  });
+  const response = await fetch(downloadUrl, { cache: 'no-store' });
+
+  if (!response.ok) {
+    throw new Error(`Cloudinary download failed with status ${response.status}`);
+  }
+
+  return {
+    buffer: Buffer.from(await response.arrayBuffer()),
+    contentType: response.headers.get('content-type') || 'application/octet-stream',
+  };
+}

--- a/tests/api/daily-cash-bill.test.ts
+++ b/tests/api/daily-cash-bill.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ids, jsonRequest, objectIdLike, routeParams } from '@/tests/helpers/api';
+
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  getUserIdFromRequest: vi.fn(),
+  cloudinaryAssetsFromFields: vi.fn(),
+  downloadRawAsset: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getUserIdFromRequest: mocks.getUserIdFromRequest,
+}));
+
+vi.mock('@/lib/mongodb', () => ({
+  getDb: mocks.getDb,
+}));
+
+vi.mock('@/lib/cloudinary-cleanup', () => ({
+  cloudinaryAssetsFromFields: mocks.cloudinaryAssetsFromFields,
+}));
+
+vi.mock('@/lib/cloudinary', () => ({
+  downloadRawAsset: mocks.downloadRawAsset,
+}));
+
+const recordId = ids.customer;
+const entryId = ids.transaction;
+const billUrl = 'https://res.cloudinary.com/demo/raw/upload/v1/ledger-bills/invoice.pdf';
+const billPublicId = 'ledger-bills/invoice.pdf';
+
+describe('/api/daily-cash-records/[id]/entries/[entryId]/bill', () => {
+  beforeEach(() => {
+    mocks.getDb.mockReset();
+    mocks.getUserIdFromRequest.mockReset();
+    mocks.cloudinaryAssetsFromFields.mockReset();
+    mocks.downloadRawAsset.mockReset();
+    mocks.getUserIdFromRequest.mockReturnValue(ids.user);
+  });
+
+  it('requires an authenticated user before accessing the database', async () => {
+    mocks.getUserIdFromRequest.mockReturnValue(null);
+    const { GET } = await import(
+      '@/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route'
+    );
+    const response = await GET(
+      jsonRequest(`http://localhost/api/daily-cash-records/${recordId}/entries/${entryId}/bill`),
+      routeParams({ id: recordId, entryId })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.getDb).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid record or entry IDs before accessing the database', async () => {
+    const { GET } = await import(
+      '@/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route'
+    );
+    const response = await GET(
+      jsonRequest('http://localhost/api/daily-cash-records/bad/entries/bad/bill'),
+      routeParams({ id: 'bad', entryId: 'bad' })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.getDb).not.toHaveBeenCalled();
+  });
+
+  it('serves an owned Cloudinary PDF through the authenticated app route', async () => {
+    const findOne = vi.fn().mockResolvedValue({
+      entries: [{
+        _id: objectIdLike(entryId),
+        billUrl,
+        billPublicId,
+      }],
+    });
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne })),
+    });
+    mocks.cloudinaryAssetsFromFields.mockReturnValue([{
+      publicId: billPublicId,
+      resourceType: 'raw',
+    }]);
+    mocks.downloadRawAsset.mockResolvedValue({
+      buffer: Buffer.from('%PDF-1.7 secure invoice'),
+      // Raw assets can be returned as octet-stream on some Cloudinary plans.
+      // The route validates the PDF signature and sets the browser MIME type.
+      contentType: 'application/octet-stream',
+    });
+
+    const { GET } = await import(
+      '@/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route'
+    );
+    const response = await GET(
+      jsonRequest(`http://localhost/api/daily-cash-records/${recordId}/entries/${entryId}/bill`),
+      routeParams({ id: recordId, entryId })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/pdf');
+    expect(response.headers.get('content-disposition')).toContain('invoice.pdf');
+    expect(response.headers.get('cache-control')).toBe('private, no-store, max-age=0');
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe(
+      '%PDF-1.7 secure invoice'
+    );
+    expect(findOne).toHaveBeenCalledWith(
+      {
+        _id: expect.any(Object),
+        userId: ids.user,
+        'entries._id': expect.any(Object),
+      },
+      {
+        projection: {
+          entries: { $elemMatch: { _id: expect.any(Object) } },
+        },
+      }
+    );
+    expect(mocks.cloudinaryAssetsFromFields).toHaveBeenCalledWith({
+      publicIds: [billPublicId],
+      urls: [billUrl],
+    });
+    expect(mocks.downloadRawAsset).toHaveBeenCalledWith(billPublicId);
+  });
+
+  it('does not expose an attachment outside the signed-in user record', async () => {
+    const findOne = vi.fn().mockResolvedValue(null);
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne })),
+    });
+
+    const { GET } = await import(
+      '@/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route'
+    );
+    const response = await GET(
+      jsonRequest(`http://localhost/api/daily-cash-records/${recordId}/entries/${entryId}/bill`),
+      routeParams({ id: recordId, entryId })
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.downloadRawAsset).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-PDF attachment instead of proxying arbitrary files', async () => {
+    const findOne = vi.fn().mockResolvedValue({
+      entries: [{
+        _id: objectIdLike(entryId),
+        billUrl: 'https://res.cloudinary.com/demo/image/upload/bill.jpg',
+        billPublicId: 'ledger-bills/bill',
+      }],
+    });
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne })),
+    });
+    mocks.cloudinaryAssetsFromFields.mockReturnValue([{
+      publicId: 'ledger-bills/bill',
+      resourceType: 'image',
+    }]);
+
+    const { GET } = await import(
+      '@/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route'
+    );
+    const response = await GET(
+      jsonRequest(`http://localhost/api/daily-cash-records/${recordId}/entries/${entryId}/bill`),
+      routeParams({ id: recordId, entryId })
+    );
+
+    expect(response.status).toBe(404);
+    expect(mocks.downloadRawAsset).not.toHaveBeenCalled();
+  });
+
+  it('fails safely when Cloudinary does not return valid PDF bytes', async () => {
+    const findOne = vi.fn().mockResolvedValue({
+      entries: [{ _id: objectIdLike(entryId), billUrl, billPublicId }],
+    });
+    mocks.getDb.mockResolvedValue({
+      collection: vi.fn(() => ({ findOne })),
+    });
+    mocks.cloudinaryAssetsFromFields.mockReturnValue([{
+      publicId: billPublicId,
+      resourceType: 'raw',
+    }]);
+    mocks.downloadRawAsset.mockResolvedValue({
+      buffer: Buffer.from('not a PDF'),
+      contentType: 'text/plain',
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { GET } = await import(
+      '@/app/api/daily-cash-records/[id]/entries/[entryId]/bill/route'
+    );
+    const response = await GET(
+      jsonRequest(`http://localhost/api/daily-cash-records/${recordId}/entries/${entryId}/bill`),
+      routeParams({ id: recordId, entryId })
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to load the bill attachment',
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/unit/bill-attachments.test.ts
+++ b/tests/unit/bill-attachments.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDailyCashBillViewUrl,
+  isPdfBillAttachment,
+} from '@/lib/bill-attachments';
+
+describe('bill attachment view URLs', () => {
+  it('routes PDFs through the authenticated daily cash endpoint', () => {
+    const attachment = {
+      id: 'entry/id',
+      billUrl: 'https://res.cloudinary.com/demo/raw/upload/invoice',
+      billPublicId: 'ledger-bills/invoice.pdf',
+    };
+
+    expect(isPdfBillAttachment(attachment)).toBe(true);
+    expect(getDailyCashBillViewUrl('record/id', attachment)).toBe(
+      '/api/daily-cash-records/record%2Fid/entries/entry%2Fid/bill'
+    );
+  });
+
+  it('keeps image attachments on their existing URL', () => {
+    const attachment = {
+      id: 'entry',
+      billUrl: 'https://res.cloudinary.com/demo/image/upload/bill.jpg',
+      billPublicId: 'ledger-bills/bill',
+    };
+
+    expect(isPdfBillAttachment(attachment)).toBe(false);
+    expect(getDailyCashBillViewUrl('record', attachment)).toBe(attachment.billUrl);
+  });
+
+  it('returns an empty URL when no attachment is present', () => {
+    expect(getDailyCashBillViewUrl('record', { id: 'entry' })).toBe('');
+  });
+});


### PR DESCRIPTION
## **User description**
## What changed

- Add an authenticated cash-entry PDF delivery endpoint that verifies the signed-in user owns the exact daily cash record and entry.
- Retrieve raw Cloudinary PDFs with a short-lived signed server URL instead of exposing the blocked public CDN URL.
- Validate PDF magic bytes and return the file inline with private, no-store headers.
- Display invoice PDFs in a large in-site preview instead of opening a new browser tab.
- Preserve direct image attachment previews.
- Add authorization, file-integrity, and URL-routing regression tests.

## Root cause

Cloudinary accepted and stored the invoice PDF, but its free-account public PDF delivery policy returned HTTP 401 with `deny or ACL failure`. The browser therefore received no PDF bytes and displayed “Failed to load PDF document.”

## Data and security impact

- Existing saved invoice and cash-record attachments work without re-uploading or migrating data.
- Cloudinary credentials and signed download URLs remain server-side.
- A user can retrieve a PDF only through a cash record and entry owned by that user.
- Non-PDF files and invalid PDF responses are rejected.

## Validation

- Verified the exact reported Cloudinary asset downloads as an 8,587-byte `%PDF-` document through the signed server flow.
- Security audit: 0 vulnerabilities.
- TypeScript typecheck: passed.
- ESLint: 0 errors (87 pre-existing warnings).
- Unit/integration tests: 155 passed.
- Production build: passed.
- Playwright browser tests: 4 passed.


___

## **CodeAnt-AI Description**
**Show PDF bills inside the app and load them through a secure record link**

### What Changed
- PDF bill attachments now open in an in-app preview instead of asking users to open a new tab.
- PDF bills are loaded through an authenticated cash-record link that only works for the owner of that record and entry.
- Non-PDF attachments keep using their existing image preview flow.
- The app now rejects invalid or non-PDF bill files instead of trying to display them as PDFs.
- Added coverage for secure PDF access, attachment type handling, and invalid-file failures.

### Impact
`✅ Fewer failed PDF previews`
`✅ Safer access to bill attachments`
`✅ Faster bill viewing inside cash records` 
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
