### PR TITLE
Fix mixed-item invoice transaction

### DIFF
--- a/lib/invoice-stock.ts
+++ b/lib/invoice-stock.ts
@@ -148,35 +148,35 @@ async function getInventoryLookups(
   }
 
   const projection = { _id: 1, itemName: 1, itemNumber: 1, quantity: 1, buyingPrice: 1, createdAt: 1, updatedAt: 1, lastQuantityUpdatedAt: 1 };
-  const [itemsById, itemsByNumber] = await Promise.all([
-    ids.size > 0
-      ? inventoryCollection
-          .find(
-            {
-              _id: { $in: Array.from(ids, (id) => new ObjectId(id)) },
-              userId,
-            },
-            { projection, session }
-          )
-          .toArray()
-      : Promise.resolve([]),
-    itemNumbers.size > 0
-      ? inventoryCollection
-          .find(
-            {
-              userId,
-              itemNumberKey: { $in: Array.from(itemNumbers) },
-            },
-            { projection, session }
-          )
-          .toArray()
-      : Promise.resolve([]),
-  ]);
+  const lookupFilters: Record<string, unknown>[] = [];
+
+  if (ids.size > 0) {
+    lookupFilters.push({
+      _id: { $in: Array.from(ids, (id) => new ObjectId(id)) },
+    });
+  }
+  if (itemNumbers.size > 0) {
+    lookupFilters.push({
+      itemNumberKey: { $in: Array.from(itemNumbers) },
+    });
+  }
+
+  const inventoryItems = lookupFilters.length > 0
+    ? await inventoryCollection
+        .find(
+          {
+            userId,
+            $or: lookupFilters,
+          },
+          { projection, session }
+        )
+        .toArray()
+    : [];
 
   return {
-    byId: new Map(itemsById.map((item) => [item._id.toString(), item])),
+    byId: new Map(inventoryItems.map((item) => [item._id.toString(), item])),
     byNumber: new Map(
-      itemsByNumber
+      inventoryItems
         .filter((item) => item.itemNumber)
         .map((item) => [normalizeIdentifier(item.itemNumber), item])
     ),

--- a/tests/api/invoices.test.ts
+++ b/tests/api/invoices.test.ts
@@ -335,6 +335,96 @@ describe('/api/invoices stock sync', () => {
     );
   });
 
+  it('creates an invoice with linked stock and a manual item that has a part number', async () => {
+    const linkedInventoryItem = {
+      _id: objectIdLike(ids.inventory),
+      itemNumber: 'F 002 H27 738-4AR',
+      itemName: 'DIESEL FILTER SET OF 2 1/2 LITRE',
+      quantity: 61,
+      buyingPrice: 130,
+    };
+    const invoiceFind = invoiceFindChain();
+    const insertOne = vi.fn().mockResolvedValue({
+      insertedId: objectIdLike('507f1f77bcf86cd799439099'),
+    });
+    const inventoryLookup = inventoryFindChain([linkedInventoryItem]);
+    const inventory = {
+      find: inventoryLookup.find,
+      findOne: vi.fn(),
+      findOneAndUpdate: vi.fn().mockResolvedValue({
+        ...linkedInventoryItem,
+        quantity: 60,
+      }),
+    };
+    mocks.getDb.mockResolvedValue(
+      dbWithCollections({
+        invoices: { find: invoiceFind.find, insertOne },
+        customers: {},
+        transactions: {},
+        inventory,
+      })
+    );
+
+    const { POST } = await import('@/app/api/invoices/route');
+    const response = await POST(jsonRequest(
+      'http://localhost/api/invoices',
+      createBody([
+        {
+          inventoryItemId: ids.inventory,
+          itemNumber: 'F 002 H27 738-4AR',
+          itemName: 'DIESEL FILTER SET OF 2 1/2 LITRE',
+          quantity: 1,
+          unitPrice: 170,
+          unitCost: 130,
+        },
+        {
+          itemNumber: 'tmacvfs001',
+          itemName: 'gilasi',
+          quantity: 1,
+          unitPrice: 150,
+          unitCost: 105,
+        },
+      ])
+    ));
+
+    expect(response.status).toBe(201);
+    expect(inventoryLookup.find).toHaveBeenCalledTimes(1);
+    expect(inventoryLookup.find).toHaveBeenCalledWith(
+      {
+        userId: ids.user,
+        $or: [
+          { _id: { $in: [expect.any(Object)] } },
+          { itemNumberKey: { $in: ['TMACVFS001'] } },
+        ],
+      },
+      expect.objectContaining({ session: mocks.session })
+    );
+    expect(inventory.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            inventoryItemId: ids.inventory,
+            itemNumber: 'F 002 H27 738-4AR',
+            unitPrice: 170,
+            unitCost: 130,
+          }),
+          expect.objectContaining({
+            itemNumber: 'tmacvfs001',
+            itemName: 'gilasi',
+            unitPrice: 150,
+            unitCost: 105,
+          }),
+        ],
+        totalAmount: 320,
+        totalCogs: 235,
+        grossProfit: 85,
+      }),
+      { session: mocks.session }
+    );
+    expect(insertOne.mock.calls[0][0].items[1]).not.toHaveProperty('inventoryItemId');
+  });
+
   it('returns an already-created invoice for a repeated client request id', async () => {
     const existingInvoice = {
       _id: objectIdLike(ids.transaction),


### PR DESCRIPTION
## **User description**
## What changed

- Replace the two concurrent inventory lookups in invoice normalization with one indexed `$or` query.
- Preserve lookup maps by inventory ID and normalized part number from the single result set.
- Add an API regression test covering the production failure: one linked inventory item plus one manual item with a populated part number.

## Root cause

`normalizeInvoiceItemsForSave()` ran the ID lookup and part-number lookup through `Promise.all()` while both operations used the same MongoDB `ClientSession` inside `session.withTransaction()`. MongoDB's Node.js driver does not support parallel operations inside one transaction. The failing input activated both query branches at once, producing a server error before the invoice could be committed.

## Impact

Invoices can now contain both inventory-linked rows and manual rows with part numbers. Only linked rows affect stock; manual rows retain their entered part number, selling price, and cost price.

## Validation

- `pnpm vitest run tests/api/invoices.test.ts` — 19 passed
- `pnpm test:unit` — 156 passed
- `pnpm lint` — 0 errors (existing warnings only)
- `pnpm build` — passed


___

## **CodeAnt-AI Description**
**Allow invoices to save when they contain both linked stock items and manual items with part numbers**

### What Changed
- Invoice saving now looks up linked items and part-number matches in one pass, so mixed-item invoices can be processed without failing inside a transaction.
- Linked stock items still update inventory, while manual items keep their own part number, price, and cost values.
- Added a regression test for the case where an invoice includes one inventory-linked item and one manual item with a part number.

### Impact
`✅ Mixed-item invoices save successfully`
`✅ Fewer invoice save failures during stock updates`
`✅ Manual invoice lines keep their entered details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
